### PR TITLE
Add model training capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Pipeline completo para processamento de documentos PDF, DOCX e imagens, incluind
 - **Re-ranking:** Cross-Encoder (ms-marco) para maior precisão
 - **Monitoramento:** Prometheus (latência, contagem de buscas, tamanho dos resultados)
 - **CLI Interativo:** Seleção de estratégia, modelo, dimensão **e dispositivo (cpu/gpu/auto)**, modo verboso, processamento em lote com barra de progresso e estatísticas em tempo real
+- **Treinamento de Modelos:** ajuste fino de SBERT usando textos já indexados no PostgreSQL
  - **Organização:** Arquivos processados são movidos para a subpasta `processado`,
    que é ignorada em execuções futuras
 
@@ -92,7 +93,15 @@ Todos os modelos e dimensões são configuráveis no arquivo `.env`.
 - Selecionar Dispositivo (CPU/GPU/Auto)
 - Processar Arquivo / Pasta (inclui imagens)
  - Mover arquivos concluídos para a subpasta `processado` (essa pasta é ignorada ao processar pastas)
+- Treinar modelo com dados do banco
 - Sair
+
+Exemplo:
+
+```bash
+$ python main.py
+# escolha a opção "7 - Treinar modelo" para ajustar o modelo atual
+```
 
 **Flags:**
 - `--verbose`: logs detalhados

--- a/main.py
+++ b/main.py
@@ -176,6 +176,7 @@ def main():
         print(f"4 - Dispositivo (atual: {device})")
         print("5 - Arquivo")
         print("6 - Pasta")
+        print("7 - Treinar modelo")
         print("0 - Sair")
         c = input("> ").strip()
 
@@ -257,6 +258,11 @@ def main():
 
             print(f"\n=== Resumo final ===")
             print(f"  Processados: {stats['processed']}  •  Erros: {stats['errors']}  •  Tempo total: {dt:.2f}s")
+            input("ENTER para continuar…")
+
+        elif c == "7":
+            from training import train_model
+            train_model(model, dim, device)
             input("ENTER para continuar…")
 
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,8 @@ transformers>=4.30.0
 torch>=1.11.0
 scikit-learn
 nltk
+datasets
+accelerate
 
 # === Banco de dados (PostgreSQL + pgvector) ===
 psycopg2-binary

--- a/training.py
+++ b/training.py
@@ -1,0 +1,57 @@
+# training.py
+import logging
+import psycopg2
+from typing import List
+
+from sentence_transformers import SentenceTransformer, InputExample, losses
+from torch.utils.data import DataLoader
+
+from config import PG_HOST, PG_PORT, PG_USER, PG_PASSWORD, PG_DATABASE
+
+
+def _fetch_texts(dim: int) -> List[str]:
+    """Lê a coluna `content` de public.documents_<dim>."""
+    table = f"public.documents_{dim}"
+    conn = None
+    try:
+        conn = psycopg2.connect(
+            host=PG_HOST,
+            port=PG_PORT,
+            dbname=PG_DATABASE,
+            user=PG_USER,
+            password=PG_PASSWORD,
+        )
+        cur = conn.cursor()
+        cur.execute(f"SELECT content FROM {table}")
+        rows = cur.fetchall()
+        cur.close()
+        return [r[0] for r in rows]
+    except Exception as e:
+        logging.error(f"Erro ao ler dados de {table}: {e}")
+        return []
+    finally:
+        if conn:
+            conn.close()
+
+
+def train_model(model_name: str, dim: int, device: str) -> None:
+    """Ajusta modelo SBERT usando textos do PostgreSQL."""
+    texts = _fetch_texts(dim)
+    if not texts:
+        logging.error("Nenhum texto encontrado para treinamento.")
+        return
+
+    logging.info(f"Carregando modelo '{model_name}' em {device}…")
+    model = SentenceTransformer(model_name, device=device)
+
+    train_examples = [InputExample(texts=[t, t]) for t in texts]
+    train_dataloader = DataLoader(train_examples, shuffle=True, batch_size=16)
+    train_loss = losses.MultipleNegativesRankingLoss(model)
+
+    logging.info(f"Iniciando treinamento com {len(train_examples)} exemplos…")
+    model.fit(train_objectives=[(train_dataloader, train_loss)], epochs=1, show_progress_bar=True)
+
+    out_path = f"{model_name.replace('/', '_')}_finetuned_{dim}"
+    model.save(out_path)
+    logging.info(f"Modelo salvo em {out_path}")
+


### PR DESCRIPTION
## Summary
- add `training.py` for finetuning SentenceTransformer models using texts stored in PostgreSQL
- include new menu option in `main.py` to launch training
- document training feature and usage in `README`
- include `datasets` and `accelerate` in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846e4349a04832aaf021622b84345b1