### PR TITLE
Fix dotenv loading with override

### DIFF
--- a/Srv/serve.py
+++ b/Srv/serve.py
@@ -11,6 +11,7 @@ evitar OOM em GPU.
 import os
 import sys
 import logging
+from pathlib import Path
 import uvicorn
 import torch
 from typing import List, Union, Optional, Dict
@@ -21,7 +22,8 @@ from sentence_transformers import SentenceTransformer
 from dotenv import load_dotenv
 
 # ─── Carrega variáveis de ambiente do arquivo .env ──────────────────────────
-load_dotenv()
+# Busca .env no diretório do servidor e sobrescreve variáveis já definidas.
+load_dotenv(Path(__file__).resolve().with_name('.env'), override=True)
 
 EMBEDDING_MODELS = [
     m.strip()

--- a/config.py
+++ b/config.py
@@ -1,9 +1,13 @@
 #config.py
 import os
 import logging
+from pathlib import Path
 from dotenv import load_dotenv
 
-load_dotenv()
+# Carrega variáveis de ambiente buscando .env na pasta do projeto.
+# `override=True` garante que valores do arquivo substituam variáveis já
+# definidas no ambiente do sistema.
+load_dotenv(Path(__file__).resolve().with_name('.env'), override=True)
 
 # — NVD API Key (para incremental)
 NVD_API_KEY = os.getenv("NVD_API_KEY")


### PR DESCRIPTION
## Summary
- ensure `.env` is loaded from the project directory and overrides existing environment variables
- adjust embedding server to load its own `.env` with override

## Testing
- `python -m py_compile config.py Srv/serve.py`

------
https://chatgpt.com/codex/tasks/task_e_684734d56f30832a8d8d8e5dde460b55