### PR TITLE
Switch to use_cpu flag for TrainingArguments

### DIFF
--- a/training.py
+++ b/training.py
@@ -102,7 +102,7 @@ def train_model(
         per_device_train_batch_size=1,
         logging_steps=10,
         overwrite_output_dir=True,
-        no_cuda=resolved_device == "cpu",
+        use_cpu=resolved_device == "cpu",
     )
 
     trainer = Trainer(


### PR DESCRIPTION
## Summary
- use the new `use_cpu` flag in `TrainingArguments`
- verified transformers version compatibility

## Testing
- `python -m py_compile training.py`


------
https://chatgpt.com/codex/tasks/task_e_68474cfce070832abc9a3091c6cff9c4