### PR TITLE
Add logging for dataset size and device

### DIFF
--- a/training.py
+++ b/training.py
@@ -97,6 +97,8 @@ def train_model(
 
     features = Features({"text": Value("string")})
     dataset = Dataset.from_generator(text_generator, features=features)
+    dataset_len = len(dataset)
+    logging.info(f"Total de textos carregados: {dataset_len}")
 
     def tokenize_fn(examples):
         return tokenizer(
@@ -107,6 +109,7 @@ def train_model(
     collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
     resolved_device = _resolve_device(device, allow_auto_gpu)
+    logging.info(f"Dispositivo escolhido: {resolved_device}")
 
     training_args = TrainingArguments(
         output_dir=f"{base_model.replace('/', '_')}_finetuned_{dim}",


### PR DESCRIPTION
## Summary
- log dataset size after loading texts
- show which training device was selected

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684787ae499c832aa703e20b4c12cbe8