### PR TITLE
Improve training log output

### DIFF
--- a/training.py
+++ b/training.py
@@ -85,6 +85,8 @@ class ProgressCallback(TrainerCallback):
                 info["epoch"] = f"{logs['epoch']:.2f}"
             if info:
                 self.pbar.set_postfix(info)
+            # Imprime dicionário completo de logs para maior interação
+            self.pbar.write(str(logs))
 
     def on_step_end(self, args, state, control, **kwargs):
         if self.pbar:


### PR DESCRIPTION
## Summary
- display full log dictionary during training

## Testing
- `python -m py_compile training.py`

------
https://chatgpt.com/codex/tasks/task_e_68478e60fb54832a90a09e2908585960