### PR TITLE
Add evaluation options to model training

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ PG_PASSWORD=senha
 PG_DATABASE=vector_store
 
 TRAINING_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+EVAL_STEPS=500
+VALIDATION_SPLIT=0.1
 ```
 
 ### Estrutura do Projeto
@@ -56,8 +58,12 @@ TRAINING_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 1. Defina o modelo desejado em `TRAINING_MODEL_NAME` no `.env`. Se não definido, será usado `deepseek-ai/DeepSeek-R1-Distill-Llama-8B`.
 2. Processe seus documentos normalmente (opções 1 a 6 do menu) para popular a tabela `public.documents_<dim>`.
 3. Escolha a dimensão (opção 3) e o dispositivo (opção 4).
-4. Acesse **7 - Treinamento**. No submenu, defina a tabela desejada (opção 3) e se a detecção automática de GPU deve ser usada (opção 2). Depois selecione **1 - Treinar modelo**.
-5. O resultado é salvo em uma pasta `MODELNAME_finetuned_<dim>`.
+4. Acesse **7 - Treinamento**. No submenu você pode:
+   - Definir a tabela de origem (opção 3).
+   - Ajustar épocas, batch size, passos de avaliação e porcentagem de validação.
+   - Ativar ou não a detecção automática de GPU.
+   - Por fim, escolha **1 - Treinar modelo**.
+5. O resultado é salvo em uma pasta `MODELNAME_finetuned_<dim>` e o melhor modelo em `best_model`.
 
 ### Dependências
 

--- a/config.py
+++ b/config.py
@@ -58,6 +58,10 @@ SLIDING_WINDOW_OVERLAP_RATIO = float(os.getenv("SLIDING_WINDOW_OVERLAP_RATIO", "
 MAX_SEQ_LENGTH               = int(os.getenv("MAX_SEQ_LENGTH", "0"))
 SEPARATORS                   = os.getenv("SEPARATORS", "").split("|")
 
+# --- Parâmetros de treinamento
+EVAL_STEPS       = int(os.getenv("EVAL_STEPS", "500"))
+VALIDATION_SPLIT = float(os.getenv("VALIDATION_SPLIT", "0.1"))
+
 def validate_config():
     missing = []
     for var in ("PG_HOST", "PG_PORT", "PG_USER", "PG_PASSWORD", "PG_DATABASE"):

--- a/exemplo.env
+++ b/exemplo.env
@@ -22,6 +22,10 @@ SBERT_MODEL_NAME=${OLLAMA_EMBEDDING_MODEL}
 
 # Modelo da Hugging Face para treinamento (opcional)
 TRAINING_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+# Avaliação a cada N passos
+EVAL_STEPS=500
+# Porcentagem do dataset usada para validação
+VALIDATION_SPLIT=0.1
 
 # — Embeddings dimensions
 DIM_MXBAI=1024

--- a/training.py
+++ b/training.py
@@ -104,8 +104,21 @@ def train_model(
     allow_auto_gpu: bool = True,
     epochs: int = 1,
     batch_size: int = 1,
+    eval_steps: int = 500,
+    validation_split: float = 0.1,
+    max_seq_length: int = 0,
 ) -> None:
-    """Ajusta um modelo Hugging Face usando textos do PostgreSQL."""
+    """Ajusta um modelo Hugging Face usando textos do PostgreSQL.
+
+    Parameters
+    ----------
+    eval_steps : int
+        Avalia o modelo a cada ``eval_steps`` passos.
+    validation_split : float
+        Porcentagem do dataset reservada para validação.
+    max_seq_length : int
+        Comprimento máximo das sequências (0 usa ``tokenizer.model_max_length``).
+    """
     texts_iter = _fetch_texts(dim)
     try:
         first_text = next(texts_iter)
@@ -143,21 +156,32 @@ def train_model(
     logging.info(f"Total de textos carregados: {dataset_len}")
 
     def tokenize_fn(examples):
-        return tokenizer(
-            examples["text"], truncation=True, max_length=tokenizer.model_max_length
-        )
+        max_len = max_seq_length or tokenizer.model_max_length
+        return tokenizer(examples["text"], truncation=True, max_length=max_len)
 
     tokenized = dataset.map(tokenize_fn, batched=True, remove_columns=["text"])
+    split = tokenized.train_test_split(test_size=validation_split, seed=42)
+    train_ds = split["train"]
+    eval_ds = split["test"]
     collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
     resolved_device = _resolve_device(device, allow_auto_gpu)
     logging.info(f"Dispositivo escolhido: {resolved_device}")
 
+    out_dir = f"{base_model.replace('/', '_')}_finetuned_{dim}"
     training_args = TrainingArguments(
-        output_dir=f"{base_model.replace('/', '_')}_finetuned_{dim}",
+        output_dir=out_dir,
         num_train_epochs=epochs,
         per_device_train_batch_size=batch_size,
+        per_device_eval_batch_size=batch_size,
         logging_steps=10,
+        evaluation_strategy="steps",
+        eval_steps=eval_steps,
+        save_strategy="steps",
+        save_steps=eval_steps,
+        load_best_model_at_end=True,
+        metric_for_best_model="loss",
+        greater_is_better=False,
         overwrite_output_dir=True,
         use_cpu=resolved_device == "cpu",
     )
@@ -179,7 +203,8 @@ def train_model(
     trainer = Trainer(
         model=model,
         args=training_args,
-        train_dataset=tokenized,
+        train_dataset=train_ds,
+        eval_dataset=eval_ds,
         data_collator=collator,
         callbacks=[ProgressCallback()],
     )
@@ -188,7 +213,11 @@ def train_model(
     try:
         trainer.train()
         trainer.save_model(training_args.output_dir)
-        logging.info(f"Modelo salvo em {training_args.output_dir}")
+        best_dir = os.path.join(training_args.output_dir, "best_model")
+        trainer.save_model(best_dir)
+        logging.info(
+            f"Modelo salvo em {training_args.output_dir} (melhor em {best_dir})"
+        )
     except RuntimeError as e:
         if "out of memory" in str(e).lower():
             logging.error(f"Mem\u00f3ria insuficiente durante o treinamento: {e}")


### PR DESCRIPTION
## Summary
- allow configuring eval steps and validation split
- split training data for evaluation
- save best model after training
- expose new options in CLI and env example
- document new training workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684850750da8832ab34e674115d1d83a