### PR TITLE
Add question/answer columns to document tables

### DIFF
--- a/BD_PostgreSQL/Estrutura_Unificada.sql
+++ b/BD_PostgreSQL/Estrutura_Unificada.sql
@@ -23,6 +23,8 @@ CREATE OR REPLACE FUNCTION public.update_tsv_full() RETURNS trigger AS $$
 BEGIN
   NEW.tsv_full :=
     setweight(to_tsvector('public.pt_en', COALESCE(NEW.content, '')), 'A')
+    || setweight(to_tsvector('public.pt_en', COALESCE(NEW.question, '')), 'A')
+    || setweight(to_tsvector('public.pt_en', COALESCE(NEW.answer, '')), 'A')
     || setweight(to_tsvector('public.pt_en', COALESCE(NEW.metadata::text, '')), 'B');
   RETURN NEW;
 END;
@@ -31,6 +33,8 @@ $$ LANGUAGE plpgsql;
 CREATE TABLE IF NOT EXISTS public.documents_384 (
   id         BIGSERIAL    PRIMARY KEY,
   content    TEXT         NOT NULL,
+  question   TEXT,
+  answer     TEXT,
   metadata   JSONB        NOT NULL,
   embedding  VECTOR(384)  NOT NULL,
   tsv_full   TSVECTOR,

--- a/BD_PostgreSQL/README.md
+++ b/BD_PostgreSQL/README.md
@@ -64,6 +64,8 @@ Cada dimensão de embedding tem sua própria tabela no schema `public`:
 CREATE TABLE IF NOT EXISTS public.documents_384 (
   id         BIGSERIAL    PRIMARY KEY,
   content    TEXT         NOT NULL,
+  question   TEXT,
+  answer     TEXT,
   metadata   JSONB        NOT NULL,
   embedding  VECTOR(384)  NOT NULL,
   tsv_full   TSVECTOR,
@@ -84,6 +86,8 @@ CREATE OR REPLACE FUNCTION public.update_tsv_full() RETURNS trigger AS $$
 BEGIN
   NEW.tsv_full :=
     setweight(to_tsvector('public.pt_en', coalesce(NEW.content, '')), 'A') ||
+    setweight(to_tsvector('public.pt_en', coalesce(NEW.question, '')), 'A') ||
+    setweight(to_tsvector('public.pt_en', coalesce(NEW.answer, '')), 'A') ||
     setweight(to_tsvector('public.pt_en', coalesce(NEW.metadata::text, '')), 'B');
   RETURN NEW;
 END;

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Todas as dependências estão listadas em `requirements.txt`.
   expande queries com WordNet e usa sliding window quando necessário.
 - **Embeddings e Indexação:** geração de vetores com SBERT e inserção em
   streaming no PostgreSQL (pgvector), permitindo busca híbrida (RAG).
+- **Pares de Pergunta/Resposta:** as tabelas `documents_<dim>` agora incluem as
+  colunas `question` e `answer` para armazenar contextos já respondidos e
+  otimizar workflows de RAG.
 - **Re-ranking e Métricas:** Cross-Encoder para ordenar resultados e servidor
   Prometheus embutido para monitorar consultas.
 - **CLI Interativo:** escolha de estratégia, modelo, dimensão, dispositivo e


### PR DESCRIPTION
## Summary
- extend document schema with `question` and `answer` fields
- adjust tsv trigger function to index new columns
- document the schema change in SQL README
- mention Q/A columns in repository README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848920d0140832aba4d5009add655ad