### PR TITLE
Make QA/QG models configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ O arquivo `.env` possibilita ajustar diversos parâmetros do projeto:
   da geração dos embeddings.
 - **Treinamento**: `TRAINING_MODEL_NAME`, `EVAL_STEPS` e `VALIDATION_SPLIT`
   personalizam o fine-tuning de modelos da Hugging Face.
+- **Perguntas e Respostas**: `QG_MODEL` e `QA_MODEL` definem os modelos
+  usados para gerar perguntas e respostas (padrão `valhalla/t5-base-qa-qg-hl`).
+  Para textos em português, experimente
+  `pierreguillou/t5-base-qa-qg-hl-portuguese-squad_v1`.
 - **Outros**: `CSV_FULL` e `CSV_INCR` podem apontar para arquivos CSV locais de
   vulnerabilidades (opcional).
 
@@ -58,6 +62,8 @@ PG_DATABASE=vector_store
 TRAINING_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 EVAL_STEPS=500
 VALIDATION_SPLIT=0.1
+QG_MODEL=valhalla/t5-base-qa-qg-hl
+QA_MODEL=${QG_MODEL}
 ```
 
 ### Estrutura do Projeto

--- a/config.py
+++ b/config.py
@@ -30,6 +30,9 @@ MINILM_L6_V2            = os.getenv("MINILM_L6_V2")
 MINILM_L12_V2           = os.getenv("MINILM_L12_V2")
 MPNET_EMBEDDING_MODEL   = os.getenv("MPNET_EMBEDDING_MODEL")
 SBERT_MODEL_NAME        = os.getenv("SBERT_MODEL_NAME")
+# Modelos para geração de perguntas e respostas
+QG_MODEL = os.getenv("QG_MODEL", "valhalla/t5-base-qa-qg-hl")
+QA_MODEL = os.getenv("QA_MODEL", QG_MODEL)
 TRAINING_MODEL_NAME    = os.getenv(
     "TRAINING_MODEL_NAME",
     "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",

--- a/exemplo.env
+++ b/exemplo.env
@@ -26,6 +26,9 @@ TRAINING_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 EVAL_STEPS=500
 # Porcentagem do dataset usada para validação
 VALIDATION_SPLIT=0.1
+# Modelos para geração de perguntas e respostas
+QG_MODEL=valhalla/t5-base-qa-qg-hl
+QA_MODEL=${QG_MODEL}
 
 # — Embeddings dimensions
 DIM_MXBAI=1024

--- a/pg_storage.py
+++ b/pg_storage.py
@@ -7,7 +7,15 @@ import torch
 from adaptive_chunker import hierarchical_chunk_generator, get_sbert_model
 from sentence_transformers import CrossEncoder
 from question_generation import pipeline
-from config import PG_HOST, PG_PORT, PG_USER, PG_PASSWORD, PG_DATABASE
+from config import (
+    PG_HOST,
+    PG_PORT,
+    PG_USER,
+    PG_PASSWORD,
+    PG_DATABASE,
+    QG_MODEL,
+    QA_MODEL,
+)
 from metrics import record_metrics
 
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:128"
@@ -75,16 +83,20 @@ def generate_qa(text: str) -> tuple[str, str]:
 
     if _QG_PIPELINE is None:
         try:
-            _QG_PIPELINE = pipeline("question-generation")
+            _QG_PIPELINE = pipeline("question-generation", model=QG_MODEL)
         except Exception as e:
-            logging.error(f"Falha ao carregar pipeline de question generation: {e}")
+            logging.error(
+                f"Falha ao carregar pipeline de question generation ({QG_MODEL}): {e}"
+            )
             return "", ""
 
     if _QA_PIPELINE is None:
         try:
-            _QA_PIPELINE = pipeline("question-answering")
+            _QA_PIPELINE = pipeline("question-answering", model=QA_MODEL)
         except Exception as e:
-            logging.error(f"Falha ao carregar pipeline de question answering: {e}")
+            logging.error(
+                f"Falha ao carregar pipeline de question answering ({QA_MODEL}): {e}"
+            )
             return "", ""
 
     try:


### PR DESCRIPTION
## Summary
- add QG_MODEL and QA_MODEL settings to `config.py`
- use the configured models in `pg_storage.py`
- document QA/QG models in README and example env file

## Testing
- `python -m py_compile config.py pg_storage.py main.py training.py`

------
https://chatgpt.com/codex/tasks/task_e_6848d06aa618832a8a28c235133fb62a