### PR TITLE
Add diagnostics for empty QA generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ Todas as dependências estão listadas em `requirements.txt`.
   streaming no PostgreSQL (pgvector), permitindo busca híbrida (RAG).
 - **Pares de Pergunta/Resposta:** as tabelas `documents_<dim>` agora incluem as
   colunas `question` e `answer` para armazenar contextos já respondidos e
-  otimizar workflows de RAG.
+  otimizar workflows de RAG. Se a geração falhar, um *warning* indica o índice do
+  chunk e o arquivo correspondente.
 - **Re-ranking e Métricas:** Cross-Encoder para ordenar resultados e servidor
   Prometheus embutido para monitorar consultas.
 - **CLI Interativo:** escolha de estratégia, modelo, dimensão, dispositivo e

--- a/pg_storage.py
+++ b/pg_storage.py
@@ -114,6 +114,10 @@ def generate_qa(text: str) -> tuple[str, str]:
             qa_res = _QA_PIPELINE({"question": question, "context": text})
             if isinstance(qa_res, dict):
                 answer = qa_res.get("answer", "")
+
+        if not question or not answer:
+            logging.warning("Pergunta ou resposta vazia gerada em generate_qa")
+
         return question, answer
     except Exception as e:
         logging.error(f"Erro ao gerar pergunta e resposta: {e}")
@@ -167,6 +171,11 @@ def save_to_postgres(filename: str,
             clean = chunk.replace("\x00", "")
             emb = generate_embedding(clean, embedding_model, embedding_dim, device_use)
             question, answer = generate_qa(clean)
+
+            if not question or not answer:
+                logging.warning(
+                    f"QA vazio no chunk {idx} do arquivo '{filename}'"
+                )
 
             # Metadata mantém todas as chaves originais + __parent e __chunk_index
             rec = {**metadata, "__parent": filename, "__chunk_index": idx,


### PR DESCRIPTION
## Summary
- warn when question or answer generation returns empty
- log chunk index and file name when QA pair is empty
- document this warning behaviour in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849874124d0832abec3f156e6556b0d