### PR TITLE
Handle optional question_generation import

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ QA_MODEL=${QG_MODEL}
 - `psycopg2-binary`
 - `question-generation`
 
+`pg_storage.py` tenta importar o pacote `question_generation`. Caso a
+dependência não esteja disponível, uma mensagem de erro é registrada e a função
+`generate_qa` retorna pares vazios.
+
 Todas as dependências estão listadas em `requirements.txt`.
 
 ---

--- a/pg_storage.py
+++ b/pg_storage.py
@@ -6,7 +6,14 @@ import psycopg2
 import torch
 from adaptive_chunker import hierarchical_chunk_generator, get_sbert_model
 from sentence_transformers import CrossEncoder
-from question_generation import pipeline as qg_pipeline
+try:
+    from question_generation import pipeline as qg_pipeline
+    _QG_AVAILABLE = True
+except Exception as e:
+    logging.error(f"Falha ao importar question_generation: {e}")
+    qg_pipeline = None
+    _QG_AVAILABLE = False
+
 from transformers import pipeline as hf_pipeline
 from config import (
     PG_HOST,
@@ -89,6 +96,10 @@ def generate_qa(text: str) -> tuple[str, str]:
 
     if len(text.strip()) < 50:
         logging.info("Texto muito curto para gerar QA; pulando")
+        return "", ""
+
+    if not _QG_AVAILABLE:
+        logging.error("Modulo question_generation ausente; pulando geracao de QA")
         return "", ""
 
     if _QG_PIPELINE is None:


### PR DESCRIPTION
## Summary
- make question_generation optional in `pg_storage`
- mention missing module behaviour in docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684996a42a48832a8b383b0af1a2f870