### PR TITLE
Document chunk size guidance for QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ O arquivo `.env` possibilita ajustar diversos parâmetros do projeto:
   usados para gerar perguntas e respostas (padrão `valhalla/t5-base-qa-qg-hl`).
   Para textos em português, experimente
   `pierreguillou/t5-base-qa-qg-hl-portuguese-squad_v1`.
+  **Recomenda-se que `CHUNK_SIZE` seja de no máximo 512 ao gerar perguntas e respostas.**
 - **Outros**: `CSV_FULL` e `CSV_INCR` podem apontar para arquivos CSV locais de
   vulnerabilidades (opcional).
 

--- a/exemplo.env
+++ b/exemplo.env
@@ -43,8 +43,8 @@ OCR_LANGUAGES=eng+por
 TESSERACT_CONFIG=""
 PDF2IMAGE_TIMEOUT=600
 
-# — Parâmetros de chunking
-CHUNK_SIZE=1024
+# — Parâmetros de chunking (recomende <=512 para perguntas/respostas)
+CHUNK_SIZE=512
 CHUNK_OVERLAP=700
 SLIDING_WINDOW_OVERLAP_RATIO=0.25
 MAX_SEQ_LENGTH=128


### PR DESCRIPTION
## Summary
- clarify that QG/QA tasks should work with a maximum `CHUNK_SIZE` of 512
- update sample env file with the recommended value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a0d70574832aac1bfd827b458f0b