### PR TITLE
Add missing unit tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,68 @@
+import importlib
+import os
+import types
+import sys
+
+import pytest
+
+
+def load_main(monkeypatch):
+    env = {
+        'PG_HOST': 'x', 'PG_PORT': '5432', 'PG_USER': 'u', 'PG_PASSWORD': 'p', 'PG_DATABASE': 'd',
+        'OLLAMA_EMBEDDING_MODEL': 'm1', 'SERAFIM_EMBEDDING_MODEL': 'm2',
+        'MINILM_L6_V2': 'm3', 'MINILM_L12_V2': 'm4', 'MPNET_EMBEDDING_MODEL': 'm5',
+        'DIM_MXBAI': '1', 'DIM_SERAFIM': '1', 'DIM_MINILM_L6': '1', 'DIM_MINIL12': '1', 'DIM_MPNET': '1'
+    }
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    # dummy heavy deps
+    monkeypatch.setitem(sys.modules, 'fitz', types.ModuleType('fitz'))
+    monkeypatch.setitem(sys.modules, 'pdfplumber', types.ModuleType('pdfplumber'))
+    monkeypatch.setitem(sys.modules, 'pytesseract', types.ModuleType('pytesseract'))
+    high = types.ModuleType('pdfminer.high_level')
+    high.extract_text = lambda p: ''
+    monkeypatch.setitem(sys.modules, 'pdfminer.high_level', high)
+    monkeypatch.setitem(sys.modules, 'pdfminer', types.ModuleType('pdfminer'))
+    loaders = types.ModuleType('langchain_community.document_loaders')
+    loaders.PyPDFLoader = lambda *a, **k: types.SimpleNamespace(load=lambda: [])
+    loaders.PDFMinerLoader = lambda *a, **k: types.SimpleNamespace(load=lambda: [])
+    loaders.UnstructuredWordDocumentLoader = lambda *a, **k: types.SimpleNamespace(load=lambda: [])
+    monkeypatch.setitem(sys.modules, 'langchain_community.document_loaders', loaders)
+    pil = types.ModuleType('PIL'); pil.Image = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, 'PIL', pil)
+    monkeypatch.setitem(sys.modules, 'psycopg2', types.ModuleType('psycopg2'))
+    monkeypatch.setitem(sys.modules, 'torch', types.ModuleType('torch'))
+    st_mod = types.ModuleType('sentence_transformers'); st_mod.CrossEncoder = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, 'sentence_transformers', st_mod)
+    qg_mod = types.ModuleType('question_generation'); qg_mod.pipeline = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, 'question_generation', qg_mod)
+    tf_mod = types.ModuleType('transformers'); tf_mod.pipeline = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, 'transformers', tf_mod)
+    tqdm_mod = types.ModuleType('tqdm'); tqdm_mod.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, 'tqdm', tqdm_mod)
+    prom = types.ModuleType('prometheus_client')
+    prom.start_http_server = lambda *a, **k: None
+    prom.Counter = prom.Histogram = prom.Gauge = lambda *a, **k: types.SimpleNamespace(inc=lambda *a, **k: None, observe=lambda *a, **k: None, set=lambda *a, **k: None)
+    monkeypatch.setitem(sys.modules, 'prometheus_client', prom)
+    dotenv = types.ModuleType('dotenv'); dotenv.load_dotenv = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, 'dotenv', dotenv)
+
+    import config
+    importlib.reload(config)
+    monkeypatch.setattr(config, 'validate_config', lambda: None)
+    import metrics, utils
+    monkeypatch.setattr(metrics, 'start_metrics_server', lambda *a, **k: None)
+    monkeypatch.setattr(utils, 'setup_logging', lambda: None)
+    import main
+    importlib.reload(main)
+    return main
+
+
+def test_select_functions(monkeypatch):
+    main = load_main(monkeypatch)
+    monkeypatch.setattr('builtins.input', lambda prompt='': '2')
+    assert main.select_strategy('pypdf') == main.STRATEGY_OPTIONS[1]
+    assert main.select_embedding('m1') == main.EMBED_MODELS['2']
+    assert main.select_dimension(1) == main.DIMENSIONS['2']
+

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,65 @@
+import importlib
+import types
+import sys
+
+import pytest
+
+
+@pytest.fixture()
+def extractors_module(monkeypatch):
+    dummy = types.ModuleType('fitz')
+    monkeypatch.setitem(sys.modules, 'fitz', dummy)
+    monkeypatch.setitem(sys.modules, 'pdfplumber', types.ModuleType('pdfplumber'))
+    monkeypatch.setitem(sys.modules, 'pytesseract', types.ModuleType('pytesseract'))
+    pdfminer_high = types.ModuleType('pdfminer.high_level')
+    pdfminer_high.extract_text = lambda p: ''
+    monkeypatch.setitem(sys.modules, 'pdfminer.high_level', pdfminer_high)
+    monkeypatch.setitem(sys.modules, 'pdfminer', types.ModuleType('pdfminer'))
+    loaders = types.ModuleType('langchain_community.document_loaders')
+    loaders.PyPDFLoader = lambda *a, **k: types.SimpleNamespace(load=lambda: [])
+    loaders.PDFMinerLoader = lambda *a, **k: types.SimpleNamespace(load=lambda: [])
+    loaders.UnstructuredWordDocumentLoader = lambda *a, **k: types.SimpleNamespace(load=lambda: [])
+    monkeypatch.setitem(sys.modules, 'langchain_community.document_loaders', loaders)
+    pil_module = types.ModuleType('PIL')
+    pil_module.Image = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, 'PIL', pil_module)
+    import extractors
+    importlib.reload(extractors)
+    return extractors
+
+
+class DummyStrategy:
+    def __init__(self, name):
+        self.name = name
+        self.calls = []
+    def extract(self, path):
+        self.calls.append(path)
+        return f"text from {self.name}"
+
+
+def test_docx_uses_unstructured(extractors_module, monkeypatch):
+    dummy = DummyStrategy('unstructured')
+    monkeypatch.setitem(extractors_module.STRATEGIES_MAP, 'unstructured', dummy)
+    result = extractors_module.extract_text('file.docx', 'pypdf')
+    assert result == 'text from unstructured'
+    assert dummy.calls == ['file.docx']
+
+
+def test_image_uses_image_strategy(extractors_module, monkeypatch):
+    dummy = DummyStrategy('image')
+    monkeypatch.setitem(extractors_module.STRATEGIES_MAP, 'image', dummy)
+    result = extractors_module.extract_text('photo.png', 'pdfminer')
+    assert result == 'text from image'
+    assert dummy.calls == ['photo.png']
+
+
+def test_pdf_fallback_to_pdfminer(extractors_module, monkeypatch):
+    primary = DummyStrategy('pypdf')
+    primary.extract = lambda path: ''
+    monkeypatch.setitem(extractors_module.STRATEGIES_MAP, 'pypdf', primary)
+    monkeypatch.setattr(extractors_module, 'repair_pdf', lambda p: p)
+    miner_text = 'x' * (extractors_module.OCR_THRESHOLD + 1)
+    monkeypatch.setattr(extractors_module, 'pdfminer_extract_text', lambda p: miner_text)
+    result = extractors_module.extract_text('file.pdf', 'pypdf')
+    assert result == miner_text
+

--- a/tests/test_pg_storage.py
+++ b/tests/test_pg_storage.py
@@ -1,0 +1,117 @@
+import types
+import contextlib
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture()
+def pg(monkeypatch):
+    dummy_prom = types.ModuleType('prometheus_client')
+    class _M:
+        def inc(self):
+            pass
+        def observe(self, *a):
+            pass
+        def set(self, *a):
+            pass
+    dummy_prom.start_http_server = lambda *a, **k: None
+    dummy_prom.Counter = lambda *a, **k: _M()
+    dummy_prom.Histogram = lambda *a, **k: _M()
+    dummy_prom.Gauge = lambda *a, **k: _M()
+    monkeypatch.setitem(sys.modules, 'prometheus_client', dummy_prom)
+    dummy_psy = types.ModuleType('psycopg2')
+    dummy_psy.connect = lambda **k: None
+    monkeypatch.setitem(sys.modules, 'psycopg2', dummy_psy)
+    dummy_torch = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(is_available=lambda: True, empty_cache=lambda: None),
+        no_grad=lambda: contextlib.nullcontext()
+    )
+    monkeypatch.setitem(sys.modules, 'torch', dummy_torch)
+    st_mod = types.ModuleType('sentence_transformers')
+    class DummyCE:
+        def __init__(self, *a, **k):
+            pass
+        def predict(self, pairs):
+            return [0.5 for _ in pairs]
+    st_mod.CrossEncoder = DummyCE
+    monkeypatch.setitem(sys.modules, 'sentence_transformers', st_mod)
+    qg_mod = types.ModuleType('question_generation'); qg_mod.pipeline = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, 'question_generation', qg_mod)
+    tf_mod = types.ModuleType('transformers'); tf_mod.pipeline = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, 'transformers', tf_mod)
+    import pg_storage
+    importlib.reload(pg_storage)
+    return pg_storage
+
+
+class DummyTorch:
+    def __init__(self):
+        self.cuda = types.SimpleNamespace(is_available=lambda: True, empty_cache=lambda: None)
+    def no_grad(self):
+        return contextlib.nullcontext()
+
+
+def test_generate_embedding_pad(pg, monkeypatch):
+    dummy_torch = DummyTorch()
+    monkeypatch.setattr(pg, 'torch', dummy_torch)
+    model = types.SimpleNamespace(encode=lambda text, convert_to_numpy=True: [1, 2])
+    monkeypatch.setattr(pg, 'get_sbert_model', lambda n, device: model)
+    result = pg.generate_embedding('txt', 'm', 5, 'cuda')
+    assert result == [1, 2, 0.0, 0.0, 0.0]
+
+
+def test_generate_embedding_fallback(pg, monkeypatch):
+    dummy_torch = DummyTorch()
+    monkeypatch.setattr(pg, 'torch', dummy_torch)
+    def get_model(name, device):
+        if device == 'cuda':
+            return types.SimpleNamespace(encode=lambda *a, **k: (_ for _ in ()).throw(RuntimeError('out of memory')))
+        return types.SimpleNamespace(encode=lambda *a, **k: [0.1, 0.2, 0.3])
+    monkeypatch.setattr(pg, 'get_sbert_model', get_model)
+    result = pg.generate_embedding('txt', 'm', 3, 'cuda')
+    assert result == [0.1, 0.2, 0.3]
+
+
+class DummyConn:
+    def __init__(self):
+        self.cur = DummyCursor()
+    def cursor(self):
+        return self.cur
+    def commit(self):
+        pass
+    def rollback(self):
+        pass
+    def close(self):
+        pass
+
+class DummyCursor:
+    def __init__(self):
+        self.calls = []
+        self.i = 1
+    def execute(self, q, params):
+        self.calls.append((q, params))
+    def fetchone(self):
+        val = self.i
+        self.i += 1
+        return [val]
+
+class DummyCE:
+    def predict(self, pairs):
+        return [0.5 for _ in pairs]
+
+
+def test_save_to_postgres(pg, monkeypatch):
+    monkeypatch.setattr(pg.psycopg2, 'connect', lambda **k: DummyConn())
+    monkeypatch.setattr(pg, 'hierarchical_chunk_generator', lambda t,m,*a,**k: ['c1','c2'])
+    monkeypatch.setattr(pg, 'generate_embedding', lambda text, m, d, device: [0.0,0.0,0.0])
+    monkeypatch.setattr(pg, 'generate_qa', lambda text: ('Q','A'))
+    monkeypatch.setattr(pg, 'get_cross_encoder', lambda model, device: DummyCE())
+    res = pg.save_to_postgres('f','txt', {'__query':'q'}, 'm', 3, 'cpu')
+    assert len(res) == 2
+    assert res[0]['id'] == 1
+    assert res[0]['question'] == 'Q'
+    assert res[0]['answer'] == 'A'
+    assert 'rerank_score' in res[0]
+


### PR DESCRIPTION
## Summary
- add extractor tests covering strategy selection and fallbacks
- add pg_storage tests for embedding generation and DB writes
- add CLI tests for selection helpers
- mock heavy dependencies so tests run quickly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a70b249c832aab3071cea6759c75