### PR TITLE
Fix QA pipeline call and adjust example env

### DIFF
--- a/exemplo.env
+++ b/exemplo.env
@@ -45,7 +45,7 @@ PDF2IMAGE_TIMEOUT=600
 
 # — Parâmetros de chunking (recomende <=512 para perguntas/respostas)
 CHUNK_SIZE=512
-CHUNK_OVERLAP=700
+CHUNK_OVERLAP=128
 SLIDING_WINDOW_OVERLAP_RATIO=0.25
 MAX_SEQ_LENGTH=128
 SEPARATORS="\n\n|\n|.|!|?|;"


### PR DESCRIPTION
## Summary
- avoid `FutureWarning` by using keyword arguments when calling the QA pipeline
- make nltk optional for tests
- set a safer `CHUNK_OVERLAP` in `exemplo.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e1f4fd08832aafb587c58522b6cc