### PR TITLE
Document Python 3.9+ requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 ### Instalação
 
+Certifique-se de ter o Python 3.9 ou superior instalado.
+
 Clone o repositório e utilize o script `init-env.sh` para criar e ativar o
 ambiente virtual automaticamente:
 

--- a/Srv/README.md
+++ b/Srv/README.md
@@ -44,7 +44,7 @@ Este repositório contém um microserviço HTTP desenvolvido com [FastAPI](https
 
 ## Requisitos
 
-- Python 3.8+
+- Python 3.9+
 - GPU (opcional, recomendado para alto desempenho)
 - Acesso à internet (para download dos modelos na primeira execução)
 

--- a/Srv/requirements.txt
+++ b/Srv/requirements.txt
@@ -1,3 +1,4 @@
+# Requires Python 3.9+ (server uses 3.9 features)
 fastapi
 uvicorn
 torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 #requirements.txt
+# Requires Python 3.9+ (some scripts use 3.9 features)
 # === Gestão de variáveis de ambiente ===
 python-dotenv
 


### PR DESCRIPTION
## Summary
- note that Python 3.9+ is required
- mention the version in the embedding server docs
- clarify Python version in requirements files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684adedad788832a81794525d6b64b8f