### PR TITLE
Add QA training menu and database settings

### DIFF
--- a/BD_PostgreSQL/Estrutura_Sem_QA.sql
+++ b/BD_PostgreSQL/Estrutura_Sem_QA.sql
@@ -1,0 +1,235 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+DROP TEXT SEARCH CONFIGURATION IF EXISTS public.pt_en;
+DROP TEXT SEARCH DICTIONARY IF EXISTS public.pt_stem;
+DROP TEXT SEARCH DICTIONARY IF EXISTS public.eng_stem;
+
+CREATE TEXT SEARCH DICTIONARY public.pt_stem (
+  TEMPLATE = snowball,
+  LANGUAGE = portuguese
+);
+CREATE TEXT SEARCH DICTIONARY public.eng_stem (
+  TEMPLATE = snowball,
+  LANGUAGE = english
+);
+
+CREATE TEXT SEARCH CONFIGURATION public.pt_en (COPY = pg_catalog.simple);
+ALTER TEXT SEARCH CONFIGURATION public.pt_en
+  ALTER MAPPING FOR asciiword, asciihword, hword_asciipart
+    WITH public.pt_stem, public.eng_stem, simple;
+
+CREATE OR REPLACE FUNCTION public.update_tsv_full() RETURNS trigger AS $$
+BEGIN
+  NEW.tsv_full :=
+    setweight(to_tsvector('public.pt_en', COALESCE(NEW.content, '')), 'A')
+    || setweight(to_tsvector('public.pt_en', COALESCE(NEW.metadata::text, '')), 'B');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE IF NOT EXISTS public.documents_384 (
+  id         BIGSERIAL    PRIMARY KEY,
+  content    TEXT         NOT NULL,
+  metadata   JSONB        NOT NULL,
+  embedding  VECTOR(384)  NOT NULL,
+  tsv_full   TSVECTOR,
+  created_at TIMESTAMPTZ  DEFAULT now()
+);
+DROP TRIGGER IF EXISTS tsv_full_trigger ON public.documents_384;
+CREATE TRIGGER tsv_full_trigger
+  BEFORE INSERT OR UPDATE ON public.documents_384
+  FOR EACH ROW EXECUTE FUNCTION public.update_tsv_full();
+CREATE INDEX IF NOT EXISTS idx_docs384_emb_hnsw ON public.documents_384 USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 200);
+CREATE INDEX IF NOT EXISTS idx_docs384_emb_ivf ON public.documents_384 USING ivfflat (embedding vector_cosine_ops) WITH (lists = 400);
+CREATE INDEX IF NOT EXISTS idx_docs384_tsv ON public.documents_384 USING gin(tsv_full);
+CREATE INDEX IF NOT EXISTS idx_docs384_meta ON public.documents_384 USING gin(metadata);
+CREATE INDEX IF NOT EXISTS idx_docs384_title ON public.documents_384 USING gin((metadata->>'title') gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_docs384_auth ON public.documents_384 USING gin((metadata->>'author') gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_docs384_type ON public.documents_384 USING gin((metadata->>'type') gin_trgm_ops) WHERE metadata ? 'type';
+CREATE INDEX IF NOT EXISTS idx_docs384_parent ON public.documents_384 USING gin((metadata->>'__parent') gin_trgm_ops);
+
+CREATE TABLE IF NOT EXISTS public.documents_768 (LIKE public.documents_384 INCLUDING ALL);
+ALTER TABLE public.documents_768 ALTER COLUMN embedding TYPE VECTOR(768);
+DROP TRIGGER IF EXISTS tsv_full_trigger ON public.documents_768;
+CREATE TRIGGER tsv_full_trigger
+  BEFORE INSERT OR UPDATE ON public.documents_768
+  FOR EACH ROW EXECUTE FUNCTION public.update_tsv_full();
+CREATE INDEX IF NOT EXISTS idx_docs768_emb_hnsw ON public.documents_768 USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 200);
+CREATE INDEX IF NOT EXISTS idx_docs768_emb_ivf ON public.documents_768 USING ivfflat (embedding vector_cosine_ops) WITH (lists = 400);
+CREATE INDEX IF NOT EXISTS idx_docs768_tsv ON public.documents_768 USING gin(tsv_full);
+CREATE INDEX IF NOT EXISTS idx_docs768_meta ON public.documents_768 USING gin(metadata);
+CREATE INDEX IF NOT EXISTS idx_docs768_title ON public.documents_768 USING gin((metadata->>'title') gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_docs768_auth ON public.documents_768 USING gin((metadata->>'author') gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_docs768_type ON public.documents_768 USING gin((metadata->>'type') gin_trgm_ops) WHERE metadata ? 'type';
+CREATE INDEX IF NOT EXISTS idx_docs768_parent ON public.documents_768 USING gin((metadata->>'__parent') gin_trgm_ops);
+
+CREATE TABLE IF NOT EXISTS public.documents_1024 (LIKE public.documents_384 INCLUDING ALL);
+ALTER TABLE public.documents_1024 ALTER COLUMN embedding TYPE VECTOR(1024);
+DROP TRIGGER IF EXISTS tsv_full_trigger ON public.documents_1024;
+CREATE TRIGGER tsv_full_trigger
+  BEFORE INSERT OR UPDATE ON public.documents_1024
+  FOR EACH ROW EXECUTE FUNCTION public.update_tsv_full();
+CREATE INDEX IF NOT EXISTS idx_docs1024_emb_hnsw ON public.documents_1024 USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 200);
+CREATE INDEX IF NOT EXISTS idx_docs1024_emb_ivf ON public.documents_1024 USING ivfflat (embedding vector_cosine_ops) WITH (lists = 400);
+CREATE INDEX IF NOT EXISTS idx_docs1024_tsv ON public.documents_1024 USING gin(tsv_full);
+CREATE INDEX IF NOT EXISTS idx_docs1024_meta ON public.documents_1024 USING gin(metadata);
+CREATE INDEX IF NOT EXISTS idx_docs1024_title ON public.documents_1024 USING gin((metadata->>'title') gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_docs1024_auth ON public.documents_1024 USING gin((metadata->>'author') gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_docs1024_type ON public.documents_1024 USING gin((metadata->>'type') gin_trgm_ops) WHERE metadata ? 'type';
+CREATE INDEX IF NOT EXISTS idx_docs1024_parent ON public.documents_1024 USING gin((metadata->>'__parent') gin_trgm_ops);
+
+CREATE TABLE IF NOT EXISTS public.documents_1536 (LIKE public.documents_384 INCLUDING ALL);
+ALTER TABLE public.documents_1536 ALTER COLUMN embedding TYPE VECTOR(1536);
+DROP TRIGGER IF EXISTS tsv_full_trigger ON public.documents_1536;
+CREATE TRIGGER tsv_full_trigger
+  BEFORE INSERT OR UPDATE ON public.documents_1536
+  FOR EACH ROW EXECUTE FUNCTION public.update_tsv_full();
+CREATE INDEX IF NOT EXISTS idx_docs1536_emb_hnsw ON public.documents_1536 USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 200);
+CREATE INDEX IF NOT EXISTS idx_docs1536_emb_ivf ON public.documents_1536 USING ivfflat (embedding vector_cosine_ops) WITH (lists = 400);
+CREATE INDEX IF NOT EXISTS idx_docs1536_tsv ON public.documents_1536 USING gin(tsv_full);
+CREATE INDEX IF NOT EXISTS idx_docs1536_meta ON public.documents_1536 USING gin(metadata);
+CREATE INDEX IF NOT EXISTS idx_docs1536_title ON public.documents_1536 USING gin((metadata->>'title') gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_docs1536_auth ON public.documents_1536 USING gin((metadata->>'author') gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_docs1536_type ON public.documents_1536 USING gin((metadata->>'type') gin_trgm_ops) WHERE metadata ? 'type';
+CREATE INDEX IF NOT EXISTS idx_docs1536_parent ON public.documents_1536 USING gin((metadata->>'__parent') gin_trgm_ops);
+
+CREATE OR REPLACE FUNCTION public.match_documents_hybrid(
+  query_embedding VECTOR,
+  query_text      TEXT      DEFAULT NULL,
+  match_count     INT       DEFAULT 5,
+  filter          JSONB     DEFAULT '{}'::jsonb,
+  weight_vec      FLOAT     DEFAULT 0.6,
+  weight_lex      FLOAT     DEFAULT 0.4,
+  min_score       FLOAT     DEFAULT 0.1,
+  pool_multiplier INT       DEFAULT 10
+) RETURNS TABLE (
+  id       BIGINT,
+  content  TEXT,
+  metadata JSONB,
+  score    FLOAT
+) LANGUAGE plpgsql AS $$
+DECLARE
+  dim      INT   := vector_dims(query_embedding);
+  tbl_full TEXT  := format('%I.%I', 'public', 'documents_' || dim);
+  sql      TEXT;
+BEGIN
+  IF dim NOT IN (384,768,1024,1536) THEN
+    RAISE EXCEPTION 'Dimensão não suportada: %', dim;
+  END IF;
+  sql := format($body$
+    WITH knn_pool AS (
+      SELECT d.metadata->>'__parent' AS parent, d.id, d.content, d.metadata,
+             d.embedding <=> $1 AS dist, d.tsv_full
+      FROM %s AS d
+      WHERE d.metadata @> $4
+      ORDER BY d.embedding <=> $1
+      LIMIT $3 * $8
+    ),
+    knn_ts AS (
+      SELECT kp.*, CASE
+        WHEN $2 IS NULL THEN NULL
+        WHEN $2 ~ '^".*"$' THEN phraseto_tsquery('public.pt_en', trim(both '"' FROM $2))
+        ELSE websearch_to_tsquery('public.pt_en', $2)
+      END AS tsq
+      FROM knn_pool AS kp
+    ),
+    scored AS (
+      SELECT id, content, metadata, 1 - dist AS sim,
+             COALESCE(
+               CASE
+                 WHEN tsq IS NOT NULL AND tsv_full @@ tsq THEN ts_rank(tsv_full, tsq)
+                 WHEN $2 IS NOT NULL AND content ILIKE '%%' || $2 || '%%' THEN 1
+                 ELSE 0
+               END, 0) AS lex_rank
+      FROM knn_ts
+    ),
+    combined AS (
+      SELECT id, content, metadata,
+             CASE WHEN lex_rank > 0 THEN $5 * sim + $6 * lex_rank ELSE sim END AS score
+      FROM scored
+    )
+    SELECT id, content, metadata, score
+    FROM combined
+    WHERE score >= $7
+    ORDER BY score DESC
+    LIMIT $3;
+  $body$, tbl_full);
+  RETURN QUERY EXECUTE sql
+    USING query_embedding, query_text, match_count, filter,
+          weight_vec, weight_lex, min_score, pool_multiplier;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.match_documents_precise(
+  query_embedding VECTOR,
+  query_text      TEXT      DEFAULT NULL,
+  match_count     INT       DEFAULT 5,
+  filter          JSONB     DEFAULT '{}'::jsonb,
+  weight_vec      FLOAT     DEFAULT 0.6,
+  weight_lex      FLOAT     DEFAULT 0.4,
+  min_cos_sim     FLOAT     DEFAULT 0.80,
+  min_score       FLOAT     DEFAULT 0.50,
+  pool_multiplier INT       DEFAULT 10
+) RETURNS TABLE (
+  id       BIGINT,
+  content  TEXT,
+  metadata JSONB,
+  score    FLOAT
+) LANGUAGE plpgsql AS $$
+DECLARE
+  dim      INT   := vector_dims(query_embedding);
+  tbl_full TEXT  := format('%I.%I', 'public', 'documents_' || dim);
+  sql      TEXT;
+BEGIN
+  IF dim NOT IN (384,768,1024,1536) THEN
+    RAISE EXCEPTION 'Dimensão não suportada: %', dim;
+  END IF;
+  sql := format($body$
+    WITH knn_pool AS (
+      SELECT d.id, d.content, d.metadata, d.embedding <#> $1 AS cos_dist, d.tsv_full
+      FROM %s AS d
+      WHERE d.metadata @> $4
+        AND d.embedding <#> $1 <= 1.0 - $7
+      ORDER BY d.embedding <#> $1
+      LIMIT $3 * $9
+    ),
+    knn_ts AS (
+      SELECT kp.*, CASE
+        WHEN $2 IS NULL THEN NULL
+        WHEN $2 ~ '^".*"$' THEN phraseto_tsquery('public.pt_en', trim(both '"' FROM $2))
+        ELSE websearch_to_tsquery('public.pt_en', $2)
+      END AS tsq
+      FROM knn_pool AS kp
+    ),
+    scored AS (
+      SELECT id, content, metadata, (1 - cos_dist) AS sim,
+             COALESCE(
+               CASE
+                 WHEN tsq IS NOT NULL AND tsv_full @@ tsq THEN ts_rank(tsv_full, tsq)
+                 WHEN $2 IS NOT NULL AND content ILIKE '%%'||$2||'%%' THEN 1
+                 ELSE 0
+               END, 0) AS lex_rank
+      FROM knn_ts
+    ),
+    combined AS (
+      SELECT id, content, metadata,
+             CASE WHEN lex_rank > 0 THEN $5*sim+$6*lex_rank ELSE sim END AS score
+      FROM scored
+    )
+    SELECT id, content, metadata, score
+    FROM combined
+    WHERE score >= $8
+    ORDER BY score DESC
+    LIMIT $3;
+  $body$, tbl_full);
+  RETURN QUERY EXECUTE sql
+    USING query_embedding, query_text, match_count, filter,
+          weight_vec, weight_lex, min_cos_sim, min_score, pool_multiplier;
+END;
+$$;
+
+SET hnsw.ef_search               = 200;
+SET ivfflat.probes               = 50;
+SET pg_trgm.similarity_threshold = 0.08;
+RESET statement_timeout;

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ PG_PORT=5432
 PG_USER=vector_store
 PG_PASSWORD=senha
 PG_DATABASE=vector_store
+PG_DB_PDF=vector_store_pdf
+PG_DB_QA=vector_store_pdf_qs
 
 TRAINING_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 EVAL_STEPS=500
@@ -86,7 +88,7 @@ QA_MODEL=${QG_MODEL}
 1. Defina o modelo desejado em `TRAINING_MODEL_NAME` no `.env`. Se não definido, será usado `deepseek-ai/DeepSeek-R1-Distill-Llama-8B`.
 2. Processe seus documentos normalmente (opções 1 a 6 do menu) para popular a tabela `public.documents_<dim>`.
 3. Escolha a dimensão (opção 3) e o dispositivo (opção 4).
-4. Acesse **7 - Treinamento**. No submenu você pode:
+4. Acesse **7 - Treinamento** ou **8 - Treinamento QA**. Nos submenus você pode:
    - Definir a tabela de origem (opção 3).
    - Ajustar épocas, batch size, passos de avaliação e porcentagem de validação.
    - Ativar ou não a detecção automática de GPU.

--- a/config.py
+++ b/config.py
@@ -18,6 +18,8 @@ PG_PORT     = int(os.getenv("PG_PORT", "5432"))
 PG_USER     = os.getenv("PG_USER")
 PG_PASSWORD = os.getenv("PG_PASSWORD")
 PG_DATABASE = os.getenv("PG_DATABASE")
+PG_DB_PDF   = os.getenv("PG_DB_PDF", "vector_store_pdf")
+PG_DB_QA    = os.getenv("PG_DB_QA", "vector_store_pdf_qs")
 
 # — CSV locais (NVD)
 CSV_FULL = os.getenv("CSV_FULL")

--- a/exemplo.env
+++ b/exemplo.env
@@ -10,6 +10,8 @@ PG_PORT=5432
 PG_USER=vector_store
 PG_PASSWORD=senha
 PG_DATABASE=vector_store
+PG_DB_PDF=vector_store_pdf
+PG_DB_QA=vector_store_pdf_qs
 
 # — Modelos de Embedding & Chunking
 OLLAMA_EMBEDDING_MODEL=mixedbread-ai/mxbai-embed-large-v1

--- a/main.py
+++ b/main.py
@@ -176,6 +176,77 @@ def training_menu(
 
     return train_dim, allow_tf_cuda, epochs, batch_size, eval_steps, val_split
 
+
+def qa_training_menu(
+    train_dim: int,
+    device: str,
+    allow_tf_cuda: bool,
+    epochs: int,
+    batch_size: int,
+    eval_steps: int,
+    val_split: float,
+) -> tuple[int, bool, int, int, int, float]:
+    """Menu de treinamento para perguntas e respostas."""
+    while True:
+        clear_screen()
+        print("*** Menu Treinamento QA ***")
+        print("1 - Treinar modelo")
+        print(
+            f"2 - Transformers detectar GPU automaticamente: {'Sim' if allow_tf_cuda else 'Não'}"
+        )
+        print(f"3 - Selecionar tabela (atual: documents_{train_dim})")
+        print(f"4 - Épocas (atual: {epochs})")
+        print(f"5 - Batch size (atual: {batch_size})")
+        print(f"6 - Avaliar a cada N passos (atual: {eval_steps})")
+        print(f"7 - Porcentagem validação (atual: {val_split})")
+        print("0 - Voltar")
+        c = input("> ").strip()
+
+        if c == "0":
+            break
+        elif c == "1":
+            from training import train_qa_model
+            train_qa_model(
+                train_dim,
+                device,
+                allow_auto_gpu=allow_tf_cuda,
+                epochs=epochs,
+                batch_size=batch_size,
+                eval_steps=eval_steps,
+                validation_split=val_split,
+                max_seq_length=MAX_SEQ_LENGTH,
+            )
+            input("ENTER para continuar…")
+        elif c == "2":
+            allow_tf_cuda = toggle_tf_cuda(allow_tf_cuda)
+        elif c == "3":
+            train_dim = select_dimension(train_dim)
+        elif c == "4":
+            inp = input(f"Número de épocas [{epochs}]: ").strip()
+            if inp.isdigit() and int(inp) > 0:
+                epochs = int(inp)
+        elif c == "5":
+            inp = input(f"Batch size [{batch_size}]: ").strip()
+            if inp.isdigit() and int(inp) > 0:
+                batch_size = int(inp)
+        elif c == "6":
+            inp = input(f"Avaliar a cada quantos passos? [{eval_steps}]: ").strip()
+            if inp.isdigit() and int(inp) > 0:
+                eval_steps = int(inp)
+        elif c == "7":
+            inp = input(f"Porcentagem de validação (0-1) [{val_split}]: ").strip()
+            try:
+                v = float(inp)
+                if 0 < v < 1:
+                    val_split = v
+            except ValueError:
+                pass
+        else:
+            print("Opção inválida.")
+            time.sleep(1)
+
+    return train_dim, allow_tf_cuda, epochs, batch_size, eval_steps, val_split
+
 def process_file(path: str, strat: str, model: str, dim: int, device: str,
                  stats: dict, processed_root: Optional[str] = None):
     """
@@ -267,6 +338,7 @@ def main():
         print("5 - Arquivo")
         print("6 - Pasta")
         print("7 - Treinamento")
+        print("8 - Treinamento QA")
         print("0 - Sair")
         c = input("> ").strip()
 
@@ -353,6 +425,17 @@ def main():
 
         elif c == "7":
             train_dim, allow_tf_cuda, epochs, batch_size, eval_steps, val_split = training_menu(
+                train_dim,
+                device,
+                allow_tf_cuda,
+                epochs,
+                batch_size,
+                eval_steps,
+                val_split,
+            )
+
+        elif c == "8":
+            train_dim, allow_tf_cuda, epochs, batch_size, eval_steps, val_split = qa_training_menu(
                 train_dim,
                 device,
                 allow_tf_cuda,

--- a/training.py
+++ b/training.py
@@ -24,10 +24,12 @@ from config import (
     PG_USER,
     PG_PASSWORD,
     PG_DATABASE,
+    PG_DB_PDF,
+    PG_DB_QA,
     TRAINING_MODEL_NAME,
 )
 
-def _fetch_texts(dim: int, batch_size: int = 1000) -> Iterator[str]:
+def _fetch_texts(dim: int, db_name: str, batch_size: int = 1000) -> Iterator[str]:
     """Lê a coluna `content` de public.documents_<dim>` de forma preguiçosa."""
     table = f"public.documents_{dim}"
     conn = None
@@ -35,7 +37,7 @@ def _fetch_texts(dim: int, batch_size: int = 1000) -> Iterator[str]:
         conn = psycopg2.connect(
             host=PG_HOST,
             port=PG_PORT,
-            dbname=PG_DATABASE,
+            dbname=db_name,
             user=PG_USER,
             password=PG_PASSWORD,
         )
@@ -49,6 +51,37 @@ def _fetch_texts(dim: int, batch_size: int = 1000) -> Iterator[str]:
                     break
                 for row in rows:
                     yield row[0]
+    except Exception as e:
+        logging.error(f"Erro ao ler dados de {table}: {e}")
+    finally:
+        if conn:
+            conn.close()
+
+def _fetch_qa_pairs(dim: int, db_name: str, batch_size: int = 1000) -> Iterator[tuple[str, str]]:
+    """Lê colunas `question` e `answer` de public.documents_<dim>."""
+    table = f"public.documents_{dim}"
+    conn = None
+    try:
+        conn = psycopg2.connect(
+            host=PG_HOST,
+            port=PG_PORT,
+            dbname=db_name,
+            user=PG_USER,
+            password=PG_PASSWORD,
+        )
+        with conn.cursor(name=f"cursor_qa_{dim}") as cur:
+            cur.itersize = batch_size
+            cur.execute(
+                f"SELECT question, answer FROM {table} "
+                "WHERE question IS NOT NULL AND answer IS NOT NULL "
+                "AND question <> '' AND answer <> ''"
+            )
+            while True:
+                rows = cur.fetchmany(batch_size)
+                if not rows:
+                    break
+                for q, a in rows:
+                    yield q, a
     except Exception as e:
         logging.error(f"Erro ao ler dados de {table}: {e}")
     finally:
@@ -121,7 +154,7 @@ def train_model(
         Comprimento máximo das sequências (0 usa ``tokenizer.model_max_length``).
     """
     def text_generator() -> Iterator[dict]:
-        for txt in _fetch_texts(dim):
+        for txt in _fetch_texts(dim, PG_DB_PDF):
             yield {"text": txt}
 
     use_cuda = _should_use_cuda(device, allow_auto_gpu)
@@ -231,6 +264,136 @@ def train_model(
         raise
 
     # Restaura variável de ambiente original
+    if prev_env is not None:
+        os.environ["TRANSFORMERS_NO_CUDA"] = prev_env
+    else:
+        os.environ.pop("TRANSFORMERS_NO_CUDA", None)
+
+
+def train_qa_model(
+    dim: int,
+    device: str,
+    model_name: Optional[str] = None,
+    allow_auto_gpu: bool = True,
+    epochs: int = 1,
+    batch_size: int = 1,
+    eval_steps: int = 500,
+    validation_split: float = 0.1,
+    max_seq_length: int = 0,
+) -> None:
+    """Ajusta modelo usando pares pergunta/resposta do PostgreSQL."""
+
+    def text_generator() -> Iterator[dict]:
+        for q, a in _fetch_qa_pairs(dim, PG_DB_QA):
+            yield {"text": f"Pergunta: {q}\nResposta: {a}"}
+
+    use_cuda = _should_use_cuda(device, allow_auto_gpu)
+    prev_env = os.environ.get("TRANSFORMERS_NO_CUDA")
+    if not use_cuda:
+        os.environ["TRANSFORMERS_NO_CUDA"] = "1"
+    else:
+        if prev_env is not None:
+            os.environ.pop("TRANSFORMERS_NO_CUDA", None)
+
+    base_model = model_name or TRAINING_MODEL_NAME
+    logging.info(f"Carregando modelo '{base_model}'…")
+    tokenizer = AutoTokenizer.from_pretrained(base_model)
+    model = AutoModelForCausalLM.from_pretrained(base_model)
+
+    features = Features({"text": Value("string")})
+    try:
+        dataset = Dataset.from_generator(text_generator, features=features)
+    except Exception:
+        logging.error("Nenhum par QA encontrado para treinamento.")
+        return
+
+    dataset_len = len(dataset)
+    logging.info(f"Total de pares carregados: {dataset_len}")
+
+    def tokenize_fn(examples):
+        max_len = max_seq_length or tokenizer.model_max_length
+        return tokenizer(examples["text"], truncation=True, max_length=max_len)
+
+    tokenized = dataset.map(tokenize_fn, batched=True, remove_columns=["text"])
+    split = tokenized.train_test_split(test_size=validation_split, seed=42)
+    train_ds = split["train"]
+    eval_ds = split["test"]
+    collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+    resolved_device = _resolve_device(device, allow_auto_gpu)
+    logging.info(f"Dispositivo escolhido: {resolved_device}")
+
+    out_dir = f"{base_model.replace('/', '_')}_finetuned_qa_{dim}"
+    base_args = {
+        "output_dir": out_dir,
+        "num_train_epochs": epochs,
+        "per_device_train_batch_size": batch_size,
+        "overwrite_output_dir": True,
+        "use_cpu": resolved_device == "cpu",
+    }
+
+    sig = inspect.signature(TrainingArguments)
+    if "evaluation_strategy" in sig.parameters:
+        base_args.update({
+            "per_device_eval_batch_size": batch_size,
+            "logging_steps": 10,
+            "evaluation_strategy": "steps",
+            "eval_steps": eval_steps,
+            "save_strategy": "steps",
+            "save_steps": eval_steps,
+            "load_best_model_at_end": True,
+            "metric_for_best_model": "loss",
+            "greater_is_better": False,
+        })
+    else:
+        base_args["logging_steps"] = 10
+
+    training_args = TrainingArguments(**base_args)
+
+    try:
+        model = model.to(resolved_device)
+    except RuntimeError as e:
+        if "out of memory" in str(e).lower():
+            logging.error(f"Memória insuficiente para mover modelo: {e}")
+            print(
+                "\n⚠️  Não há memória de vídeo suficiente. "
+                "Reduza o batch size ou selecione 'cpu' como dispositivo."
+            )
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            return
+        raise
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_ds,
+        eval_dataset=eval_ds,
+        data_collator=collator,
+        callbacks=[ProgressCallback()],
+    )
+
+    logging.info("Iniciando treinamento…")
+    try:
+        trainer.train()
+        trainer.save_model(training_args.output_dir)
+        best_dir = os.path.join(training_args.output_dir, "best_model")
+        trainer.save_model(best_dir)
+        logging.info(
+            f"Modelo salvo em {training_args.output_dir} (melhor em {best_dir})"
+        )
+    except RuntimeError as e:
+        if "out of memory" in str(e).lower():
+            logging.error(f"Memória insuficiente durante o treinamento: {e}")
+            print(
+                "\n⚠️  A GPU ficou sem memória durante o treinamento. "
+                "Tente reduzir o batch size ou utilize a CPU."
+            )
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            return
+        raise
+
     if prev_env is not None:
         os.environ["TRANSFORMERS_NO_CUDA"] = prev_env
     else:


### PR DESCRIPTION
## Summary
- support separate databases for QA and regular training
- add QA training menu and training function
- document new environment variables in README and exemplo.env
- include SQL schema without QA columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af8049c74832a9bd6fb786e47c7d1