### PR TITLE
Limit doc_stride in QA pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ O arquivo `.env` possibilita ajustar diversos parâmetros do projeto:
   Para textos em português, experimente
   `pierreguillou/t5-base-qa-qg-hl-portuguese-squad_v1`.
   **Recomenda-se que `CHUNK_SIZE` seja de no máximo 512 ao gerar perguntas e respostas.**
+  A função `generate_qa` limita automaticamente `doc_stride` para nunca exceder o
+  tamanho máximo suportado pelo tokenizer.
 - **Outros**: `CSV_FULL` e `CSV_INCR` podem apontar para arquivos CSV locais de
   vulnerabilidades (opcional).
 


### PR DESCRIPTION
## Summary
- cap doc_stride in `generate_qa` to avoid exceeding tokenizer limits
- add regression test for doc_stride
- document doc_stride handling in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b31208eb0832ab2b90a0621c7ec0e