### PR TITLE
Improve QA doc_stride calculation

### DIFF
--- a/pg_storage.py
+++ b/pg_storage.py
@@ -211,9 +211,10 @@ def generate_qa(text: str) -> tuple[str, str]:
             max_len = max_seq - specials
 
             doc_stride = max(1, min(64, tok_len - 1))
-            doc_stride = min(doc_stride, max_len - 1)
-
-            if doc_stride <= 0:
+            available = max_len - q_len
+            if available > 1:
+                doc_stride = min(doc_stride, available - 1)
+            else:
                 doc_stride = 1
 
             logging.debug(f"QA doc_stride={doc_stride} max_len={max_len}")

--- a/tests/test_pg_storage.py
+++ b/tests/test_pg_storage.py
@@ -123,6 +123,7 @@ def test_generate_qa_limits_doc_stride(pg, monkeypatch):
             self.tokenizer = types.SimpleNamespace(
                 model_max_length=16,
                 tokenize=lambda text: text.split(),
+                num_special_tokens_to_add=lambda pair=True: 2,
             )
 
         def __call__(self, question, context, **kwargs):
@@ -138,6 +139,8 @@ def test_generate_qa_limits_doc_stride(pg, monkeypatch):
     q, a = pg.generate_qa("word " * 40)
     assert q and a
     kwargs = qa.calls[0]
-    assert kwargs["doc_stride"] < qa.tokenizer.model_max_length
+    specials = qa.tokenizer.num_special_tokens_to_add(pair=True)
+    available = qa.tokenizer.model_max_length - specials - len(q.split())
+    assert kwargs["doc_stride"] < available
     assert kwargs["max_seq_len"] <= qa.tokenizer.model_max_length
 


### PR DESCRIPTION
## Summary
- adjust QA doc_stride calculation to consider available token space
- update tests for doc_stride bounds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3cf4283c832aa52709533c41d9df