### PR TITLE
Remove PG_DATABASE variable and update configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ PG_HOST=192.168.3.32
 PG_PORT=5432
 PG_USER=vector_store
 PG_PASSWORD=senha
-PG_DATABASE=vector_store
 PG_DB_PDF=vector_store_pdf
 PG_DB_QA=vector_store_pdf_qs
 

--- a/config.py
+++ b/config.py
@@ -20,7 +20,6 @@ PG_HOST     = os.getenv("PG_HOST")
 PG_PORT     = int(os.getenv("PG_PORT", "5432"))
 PG_USER     = os.getenv("PG_USER")
 PG_PASSWORD = os.getenv("PG_PASSWORD")
-PG_DATABASE = os.getenv("PG_DATABASE")
 PG_DB_PDF   = os.getenv("PG_DB_PDF")
 PG_DB_QA    = os.getenv("PG_DB_QA")
 
@@ -84,7 +83,7 @@ VALIDATION_SPLIT = float(os.getenv("VALIDATION_SPLIT", "0.1"))
 
 def validate_config():
     missing = []
-    for var in ("PG_HOST", "PG_PORT", "PG_USER", "PG_PASSWORD", "PG_DATABASE"):
+    for var in ("PG_HOST", "PG_PORT", "PG_USER", "PG_PASSWORD", "PG_DB_PDF", "PG_DB_QA"):
         if not globals().get(var):
             missing.append(var)
     if missing:

--- a/exemplo.env
+++ b/exemplo.env
@@ -9,7 +9,6 @@ PG_HOST=172.16.187.133
 PG_PORT=5432
 PG_USER=vector_store
 PG_PASSWORD=902grego1989
-PG_DATABASE=vector_store
 PG_DB_PDF=vector_store_pdf
 PG_DB_QA=vector_store_pdf_qs
 

--- a/pg_storage.py
+++ b/pg_storage.py
@@ -35,7 +35,7 @@ from config import (
     PG_PORT,
     PG_USER,
     PG_PASSWORD,
-    PG_DATABASE,
+    PG_DB_PDF,
     QG_MODEL,
     QA_MODEL,
     MAX_SEQ_LENGTH,
@@ -270,7 +270,7 @@ def save_to_postgres(filename: str,
         conn = psycopg2.connect(
             host=PG_HOST,
             port=PG_PORT,
-            dbname=PG_DATABASE,
+            dbname=PG_DB_PDF,
             user=PG_USER,
             password=PG_PASSWORD
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import pytest
 
 def load_main(monkeypatch):
     env = {
-        'PG_HOST': 'x', 'PG_PORT': '5432', 'PG_USER': 'u', 'PG_PASSWORD': 'p', 'PG_DATABASE': 'd',
+        'PG_HOST': 'x', 'PG_PORT': '5432', 'PG_USER': 'u', 'PG_PASSWORD': 'p', 'PG_DB_PDF': 'd_pdf', 'PG_DB_QA': 'd_qa',
         'OLLAMA_EMBEDDING_MODEL': 'm1', 'SERAFIM_EMBEDDING_MODEL': 'm2',
         'MINILM_L6_V2': 'm3', 'MINILM_L12_V2': 'm4', 'MPNET_EMBEDDING_MODEL': 'm5',
         'DIM_MXBAI': '1', 'DIM_SERAFIM': '1', 'DIM_MINILM_L6': '1', 'DIM_MINIL12': '1', 'DIM_MPNET': '1'

--- a/training.py
+++ b/training.py
@@ -23,7 +23,6 @@ from config import (
     PG_PORT,
     PG_USER,
     PG_PASSWORD,
-    PG_DATABASE,
     PG_DB_PDF,
     PG_DB_QA,
     TRAINING_MODEL_NAME,


### PR DESCRIPTION
## Summary
- drop deprecated `PG_DATABASE` usage
- use `PG_DB_PDF` in pg_storage
- update environment examples and docs
- fix tests for new variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c303f54c4832ab1752be63cd01e20