### PR TITLE
Add database selection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ QA_MODEL=${QG_MODEL}
 ## 🏋️ Treinamento de Modelos
 
 1. Defina o modelo desejado em `TRAINING_MODEL_NAME` no `.env`. Se não definido, será usado `deepseek-ai/DeepSeek-R1-Distill-Llama-8B`.
-2. Processe seus documentos normalmente (opções 1 a 6 do menu) para popular a tabela `public.documents_<dim>`.
+2. Processe seus documentos normalmente (opções 1 a 7 do menu) para popular a tabela `public.documents_<dim>`.
 3. Escolha a dimensão (opção 3) e o dispositivo (opção 4).
-4. Acesse **7 - Treinamento** ou **8 - Treinamento QA**. Nos submenus você pode:
+4. Acesse **8 - Treinamento** ou **9 - Treinamento QA**. Nos submenus você pode:
    - Definir a tabela de origem (opção 3).
    - Ajustar épocas, batch size, passos de avaliação e porcentagem de validação.
    - Ativar ou não a detecção automática de GPU.

--- a/pg_storage.py
+++ b/pg_storage.py
@@ -242,7 +242,8 @@ def save_to_postgres(filename: str,
                      metadata: dict,
                      embedding_model: str,
                      embedding_dim: int,
-                     device: str) -> list[dict]:
+                     device: str,
+                     db_name: str = PG_DB_PDF) -> list[dict]:
     """
     Insere no PostgreSQL cada chunk gerado em streaming pelo hierarchical_chunk_generator.
     Retorna uma lista de dicionários contendo:
@@ -251,6 +252,8 @@ def save_to_postgres(filename: str,
       - 'metadata': metadados JSONB originais + __parent e __chunk_index.
     Após inserir todos os chunks, se houver chave '__query' em metadata, executa re-ranking
     com CrossEncoder e adiciona o campo 'rerank_score' em cada dicionário antes de ordenar.
+    O parâmetro ``db_name`` permite escolher qual banco de dados será utilizado,
+    padrão ``PG_DB_PDF``.
     """
     conn = None
     inserted = []
@@ -270,7 +273,7 @@ def save_to_postgres(filename: str,
         conn = psycopg2.connect(
             host=PG_HOST,
             port=PG_PORT,
-            dbname=PG_DB_PDF,
+            dbname=db_name,
             user=PG_USER,
             password=PG_PASSWORD
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,4 +65,5 @@ def test_select_functions(monkeypatch):
     assert main.select_strategy('pypdf') == main.STRATEGY_OPTIONS[1]
     assert main.select_embedding('m1') == main.EMBED_MODELS['2']
     assert main.select_dimension(1) == main.DIMENSIONS['2']
+    assert main.select_database('d_pdf') == main.DB_OPTIONS['2']
 


### PR DESCRIPTION
## Summary
- support choosing the target database on PDF extraction
- update CLI tests and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c35492d94832a80eeeee8eba3a5eb