### PR TITLE
Enhance TyDiQA question generation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ O arquivo `.env` possibilita ajustar diversos parâmetros do projeto:
 
 Defina `QG_MODEL` como
 `Narrativa/mT5-base-finetuned-tydiQA-question-generation` e `QA_MODEL` como
-`Narrativa/mT5-base-finetuned-tydiQA-xqa`. A cobertura inclui os idiomas:
+`Narrativa/mT5-base-finetuned-tydiQA-xqa`. Para obter os melhores resultados,
+esse gerador de perguntas espera um prompt no formato
+`answer: <resposta> context: <contexto>`.
+A cobertura inclui os idiomas:
 (Afrikaans, Albanian, Amharic, Arabic, Armenian, Azerbaijani, Basque, Belarusian, Bengali, Bulgarian, Burmese, Catalan, Cebuano, Chichewa, Chinese, Corsican, Czech, Danish, Dutch, English, Esperanto, Estonian, Filipino, Finnish, French, Galician, Georgian, German, Greek, Gujarati, Haitian Creole, Hausa, Hawaiian, Hebrew, Hindi, Hmong, Hungarian, Icelandic, Igbo, Indonesian, Irish, Italian, Japanese, Javanese, Kannada, Kazakh, Khmer, Korean, Kurdish, Kyrgyz, Lao, Latin, Latvian, Lithuanian, Luxembourgish, Macedonian, Malagasy, Malay, Malayalam, Maltese, Maori, Marathi, Mongolian, Nepali, Norwegian, Pashto, Persian, Polish, Portuguese, Punjabi, Romanian, Russian, Samoan, Scottish Gaelic, Serbian, Shona, Sindhi, Sinhala, Slovak, Slovenian, Somali, Sotho, Spanish, Sundanese, Swahili, Swedish, Tajik, Tamil, Telugu, Thai, Turkish, Ukrainian, Urdu, Uzbek, Vietnamese, Welsh, West Frisian, Xhosa, Yiddish, Yoruba, Zulu.), incluindo suporte para português.
 
 ```python


### PR DESCRIPTION
## Summary
- document TyDiQA QG prompt requirements
- build `answer:` / `context:` prompts automatically in `generate_qa`
- test the new TyDiQA prompt logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c68b92a10832aa473ad52ce78be35