### PR TITLE
Add default hyperparameters for training

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ O arquivo `.env` possibilita ajustar diversos parâmetros do projeto:
   `MAX_SEQ_LENGTH` e `SEPARATORS` determinam como os textos são divididos antes
   da geração dos embeddings. Caso `MAX_SEQ_LENGTH` não seja definido, o padrão
   é `128`.
-- **Treinamento**: `TRAINING_MODEL_NAME`, `EVAL_STEPS` e `VALIDATION_SPLIT`
+- **Treinamento**: `TRAINING_MODEL_NAME`, `EVAL_STEPS`, `VALIDATION_SPLIT`,
+  `LEARNING_RATE`, `WEIGHT_DECAY`, `WARMUP_STEPS`,
+  `GRADIENT_ACCUMULATION_STEPS` e `LR_SCHEDULER_TYPE`
   personalizam o fine-tuning de modelos da Hugging Face.
 - **Perguntas e Respostas**: `QG_MODEL` e `QA_MODEL` definem os modelos
   usados para gerar perguntas e respostas (padrão `valhalla/t5-base-qa-qg-hl`).
@@ -101,6 +103,11 @@ PG_DB_QA=vector_store_pdf_qs
 TRAINING_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 EVAL_STEPS=500
 VALIDATION_SPLIT=0.1
+LEARNING_RATE=5e-5
+WEIGHT_DECAY=0.01
+WARMUP_STEPS=100
+GRADIENT_ACCUMULATION_STEPS=1
+LR_SCHEDULER_TYPE=linear
 QG_MODEL=valhalla/t5-base-qa-qg-hl
 QA_MODEL=${QG_MODEL}
 # Ativa prompt explicito no QA (opcional)

--- a/config.py
+++ b/config.py
@@ -82,6 +82,12 @@ SEPARATORS = os.getenv("SEPARATORS", "").split("|")
 # --- Parâmetros de treinamento
 EVAL_STEPS       = int(os.getenv("EVAL_STEPS", "500"))
 VALIDATION_SPLIT = float(os.getenv("VALIDATION_SPLIT", "0.1"))
+# Hiperpar\u00e2metros adicionais para o fine-tuning
+LEARNING_RATE               = float(os.getenv("LEARNING_RATE", "5e-5"))
+WEIGHT_DECAY                = float(os.getenv("WEIGHT_DECAY", "0.01"))
+WARMUP_STEPS                = int(os.getenv("WARMUP_STEPS", "100"))
+GRADIENT_ACCUMULATION_STEPS = int(os.getenv("GRADIENT_ACCUMULATION_STEPS", "1"))
+LR_SCHEDULER_TYPE           = os.getenv("LR_SCHEDULER_TYPE", "linear")
 
 def validate_config():
     missing = []

--- a/exemplo.env
+++ b/exemplo.env
@@ -27,6 +27,12 @@ TRAINING_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 EVAL_STEPS=500
 # Porcentagem do dataset usada para validação
 VALIDATION_SPLIT=0.1
+# Hiperpar\u00e2metros do treinamento
+LEARNING_RATE=5e-5
+WEIGHT_DECAY=0.01
+WARMUP_STEPS=100
+GRADIENT_ACCUMULATION_STEPS=1
+LR_SCHEDULER_TYPE=linear
 # Modelos para geração de perguntas e respostas
 ##PT-BR
 QG_MODEL=Narrativa/mT5-base-finetuned-tydiQA-question-generation

--- a/training.py
+++ b/training.py
@@ -26,6 +26,11 @@ from config import (
     PG_DB_PDF,
     PG_DB_QA,
     TRAINING_MODEL_NAME,
+    LEARNING_RATE,
+    WEIGHT_DECAY,
+    WARMUP_STEPS,
+    GRADIENT_ACCUMULATION_STEPS,
+    LR_SCHEDULER_TYPE,
 )
 
 def _fetch_texts(dim: int, db_name: str, batch_size: int = 1000) -> Iterator[str]:
@@ -140,6 +145,11 @@ def train_model(
     eval_steps: int = 500,
     validation_split: float = 0.1,
     max_seq_length: int = 0,
+    learning_rate: float = LEARNING_RATE,
+    weight_decay: float = WEIGHT_DECAY,
+    warmup_steps: int = WARMUP_STEPS,
+    gradient_accumulation_steps: int = GRADIENT_ACCUMULATION_STEPS,
+    lr_scheduler_type: str = LR_SCHEDULER_TYPE,
 ) -> None:
     """Ajusta um modelo Hugging Face usando textos do PostgreSQL.
 
@@ -217,6 +227,16 @@ def train_model(
         else:
             base_args["logging_steps"] = 10
 
+        base_args.update(
+            {
+                "learning_rate": learning_rate,
+                "weight_decay": weight_decay,
+                "warmup_steps": warmup_steps,
+                "gradient_accumulation_steps": gradient_accumulation_steps,
+                "lr_scheduler_type": lr_scheduler_type,
+            }
+        )
+
         training_args = TrainingArguments(**base_args)
 
         try:
@@ -279,6 +299,11 @@ def train_qa_model(
     eval_steps: int = 500,
     validation_split: float = 0.1,
     max_seq_length: int = 0,
+    learning_rate: float = LEARNING_RATE,
+    weight_decay: float = WEIGHT_DECAY,
+    warmup_steps: int = WARMUP_STEPS,
+    gradient_accumulation_steps: int = GRADIENT_ACCUMULATION_STEPS,
+    lr_scheduler_type: str = LR_SCHEDULER_TYPE,
 ) -> None:
     """Ajusta modelo usando pares pergunta/resposta do PostgreSQL."""
 
@@ -347,6 +372,16 @@ def train_qa_model(
             })
         else:
             base_args["logging_steps"] = 10
+
+        base_args.update(
+            {
+                "learning_rate": learning_rate,
+                "weight_decay": weight_decay,
+                "warmup_steps": warmup_steps,
+                "gradient_accumulation_steps": gradient_accumulation_steps,
+                "lr_scheduler_type": lr_scheduler_type,
+            }
+        )
 
         training_args = TrainingArguments(**base_args)
 


### PR DESCRIPTION
## Summary
- expose more training parameters through environment variables
- update example `.env` with new options
- document new variables in README
- support new hyperparameters in training functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8cf1aa7c832a976ff41e5322bee8