### PR TITLE
Expose workers for tokenization and dataloaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ O arquivo `.env` possibilita ajustar diversos parâmetros do projeto:
   é `128`.
 - **Treinamento**: `TRAINING_MODEL_NAME`, `EVAL_STEPS`, `VALIDATION_SPLIT`,
   `LEARNING_RATE`, `WEIGHT_DECAY`, `WARMUP_STEPS`,
-  `GRADIENT_ACCUMULATION_STEPS` e `LR_SCHEDULER_TYPE`
+  `GRADIENT_ACCUMULATION_STEPS`, `LR_SCHEDULER_TYPE`,
+  `TOKENIZE_NUM_PROC` e `DATALOADER_NUM_WORKERS`
   personalizam o fine-tuning de modelos da Hugging Face.
 - **Perguntas e Respostas**: `QG_MODEL` e `QA_MODEL` definem os modelos
   usados para gerar perguntas e respostas (padrão `valhalla/t5-base-qa-qg-hl`).
@@ -108,6 +109,8 @@ WEIGHT_DECAY=0.01
 WARMUP_STEPS=100
 GRADIENT_ACCUMULATION_STEPS=1
 LR_SCHEDULER_TYPE=linear
+# TOKENIZE_NUM_PROC=12
+# DATALOADER_NUM_WORKERS=12
 QG_MODEL=valhalla/t5-base-qa-qg-hl
 QA_MODEL=${QG_MODEL}
 # Ativa prompt explicito no QA (opcional)
@@ -115,6 +118,8 @@ QA_MODEL=${QG_MODEL}
 # QG_MODEL=Narrativa/mT5-base-finetuned-tydiQA-question-generation
 # QA_MODEL=Narrativa/mT5-base-finetuned-tydiQA-xqa
 ```
+Em CPUs com 12 núcleos, defina `TOKENIZE_NUM_PROC` e
+`DATALOADER_NUM_WORKERS` como `12` para máximo desempenho.
 
 ### Estrutura do Projeto
 

--- a/config.py
+++ b/config.py
@@ -88,6 +88,10 @@ WEIGHT_DECAY                = float(os.getenv("WEIGHT_DECAY", "0.01"))
 WARMUP_STEPS                = int(os.getenv("WARMUP_STEPS", "100"))
 GRADIENT_ACCUMULATION_STEPS = int(os.getenv("GRADIENT_ACCUMULATION_STEPS", "1"))
 LR_SCHEDULER_TYPE           = os.getenv("LR_SCHEDULER_TYPE", "linear")
+# Quantos processos paralelos usar ao tokenizar datasets
+TOKENIZE_NUM_PROC           = int(os.getenv("TOKENIZE_NUM_PROC", "1"))
+# Workers do PyTorch DataLoader usados pelo Trainer
+DATALOADER_NUM_WORKERS      = int(os.getenv("DATALOADER_NUM_WORKERS", "0"))
 
 def validate_config():
     missing = []

--- a/exemplo.env
+++ b/exemplo.env
@@ -33,6 +33,8 @@ WEIGHT_DECAY=0.01
 WARMUP_STEPS=100
 GRADIENT_ACCUMULATION_STEPS=1
 LR_SCHEDULER_TYPE=linear
+# TOKENIZE_NUM_PROC=12      # CPUs com 12 núcleos
+# DATALOADER_NUM_WORKERS=12 # idem acima
 # Modelos para geração de perguntas e respostas
 ##PT-BR
 QG_MODEL=Narrativa/mT5-base-finetuned-tydiQA-question-generation

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from config import (
     DIM_MXBAI, DIM_SERAFIM, DIM_MINILM_L6, DIM_MINIL12, DIM_MPNET,
     OCR_THRESHOLD, EVAL_STEPS, VALIDATION_SPLIT, MAX_SEQ_LENGTH,
     PG_DB_PDF, PG_DB_QA,
+    TOKENIZE_NUM_PROC, DATALOADER_NUM_WORKERS,
     validate_config
 )
 from extractors import extract_text
@@ -234,7 +235,9 @@ def training_menu(
     batch_size: int,
     eval_steps: int,
     val_split: float,
-) -> tuple[int, bool, int, int, int, float]:
+    tokenize_num_proc: int,
+    dataloader_num_workers: int,
+) -> tuple[int, bool, int, int, int, float, int, int]:
     """Exibe o submenu de treinamento."""
     while True:
         clear_screen()
@@ -248,6 +251,8 @@ def training_menu(
         print(f"5 - Batch size (atual: {batch_size})")
         print(f"6 - Avaliar a cada N passos (atual: {eval_steps})")
         print(f"7 - Porcentagem validação (atual: {val_split})")
+        print(f"8 - Processos de tokenização (atual: {tokenize_num_proc})")
+        print(f"9 - Workers DataLoader (atual: {dataloader_num_workers})")
         print("0 - Voltar")
         c = input("> ").strip()
 
@@ -265,6 +270,8 @@ def training_menu(
                 eval_steps=eval_steps,
                 validation_split=val_split,
                 max_seq_length=MAX_SEQ_LENGTH,
+                tokenize_num_proc=tokenize_num_proc,
+                dataloader_num_workers=dataloader_num_workers,
             )
             input("ENTER para continuar…")
 
@@ -302,7 +309,16 @@ def training_menu(
             print("Opção inválida.")
             time.sleep(1)
 
-    return train_dim, allow_tf_cuda, epochs, batch_size, eval_steps, val_split
+    return (
+        train_dim,
+        allow_tf_cuda,
+        epochs,
+        batch_size,
+        eval_steps,
+        val_split,
+        tokenize_num_proc,
+        dataloader_num_workers,
+    )
 
 
 def qa_training_menu(
@@ -313,7 +329,9 @@ def qa_training_menu(
     batch_size: int,
     eval_steps: int,
     val_split: float,
-) -> tuple[int, bool, int, int, int, float]:
+    tokenize_num_proc: int,
+    dataloader_num_workers: int,
+) -> tuple[int, bool, int, int, int, float, int, int]:
     """Menu de treinamento para perguntas e respostas."""
     while True:
         clear_screen()
@@ -327,6 +345,8 @@ def qa_training_menu(
         print(f"5 - Batch size (atual: {batch_size})")
         print(f"6 - Avaliar a cada N passos (atual: {eval_steps})")
         print(f"7 - Porcentagem validação (atual: {val_split})")
+        print(f"8 - Processos de tokenização (atual: {tokenize_num_proc})")
+        print(f"9 - Workers DataLoader (atual: {dataloader_num_workers})")
         print("0 - Voltar")
         c = input("> ").strip()
 
@@ -343,6 +363,8 @@ def qa_training_menu(
                 eval_steps=eval_steps,
                 validation_split=val_split,
                 max_seq_length=MAX_SEQ_LENGTH,
+                tokenize_num_proc=tokenize_num_proc,
+                dataloader_num_workers=dataloader_num_workers,
             )
             input("ENTER para continuar…")
         elif c == "2":
@@ -369,11 +391,30 @@ def qa_training_menu(
                     val_split = v
             except ValueError:
                 pass
+
+        elif c == "8":
+            inp = input(f"Tokenize num_proc [{tokenize_num_proc}]: ").strip()
+            if inp.isdigit() and int(inp) > 0:
+                tokenize_num_proc = int(inp)
+
+        elif c == "9":
+            inp = input(f"Dataloader workers [{dataloader_num_workers}]: ").strip()
+            if inp.isdigit() and int(inp) >= 0:
+                dataloader_num_workers = int(inp)
         else:
             print("Opção inválida.")
             time.sleep(1)
 
-    return train_dim, allow_tf_cuda, epochs, batch_size, eval_steps, val_split
+    return (
+        train_dim,
+        allow_tf_cuda,
+        epochs,
+        batch_size,
+        eval_steps,
+        val_split,
+        tokenize_num_proc,
+        dataloader_num_workers,
+    )
 
 def process_file(path: str, strat: str, model: str, dim: int, device: str,
                  db_name: str, stats: dict, processed_root: Optional[str] = None):
@@ -455,6 +496,8 @@ def main():
     batch_size = 1
     eval_steps = EVAL_STEPS
     val_split = VALIDATION_SPLIT
+    tokenize_num_proc = TOKENIZE_NUM_PROC
+    dataloader_num_workers = DATALOADER_NUM_WORKERS
     stats = {"processed": 0, "errors": 0}
     test_path = ""
 
@@ -559,7 +602,16 @@ def main():
             input("ENTER para continuar…")
 
         elif c == "8":
-            train_dim, allow_tf_cuda, epochs, batch_size, eval_steps, val_split = training_menu(
+            (
+                train_dim,
+                allow_tf_cuda,
+                epochs,
+                batch_size,
+                eval_steps,
+                val_split,
+                tokenize_num_proc,
+                dataloader_num_workers,
+            ) = training_menu(
                 train_dim,
                 device,
                 allow_tf_cuda,
@@ -567,10 +619,21 @@ def main():
                 batch_size,
                 eval_steps,
                 val_split,
+                tokenize_num_proc,
+                dataloader_num_workers,
             )
 
         elif c == "9":
-            train_dim, allow_tf_cuda, epochs, batch_size, eval_steps, val_split = qa_training_menu(
+            (
+                train_dim,
+                allow_tf_cuda,
+                epochs,
+                batch_size,
+                eval_steps,
+                val_split,
+                tokenize_num_proc,
+                dataloader_num_workers,
+            ) = qa_training_menu(
                 train_dim,
                 device,
                 allow_tf_cuda,
@@ -578,6 +641,8 @@ def main():
                 batch_size,
                 eval_steps,
                 val_split,
+                tokenize_num_proc,
+                dataloader_num_workers,
             )
 
         elif c == "10":


### PR DESCRIPTION
## Summary
- make TOKENIZE_NUM_PROC and DATALOADER_NUM_WORKERS configurable in `config.py`
- allow custom workers in `train_model` and `train_qa_model`
- expose new settings via CLI menus
- document usage and add examples in `.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da017d34c832aa794246dcafe0beb