### PR TITLE
Remove unused CSV and NVD parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ O arquivo `.env` possibilita ajustar diversos parâmetros do projeto:
   ...". Modelos generativos como `Narrativa/mT5-base-finetuned-tydiQA-xqa` devem
   ser carregados com `AutoModelForCausalLM` para que `generate` funcione. Exemplo:
 
-  ```python
+```python
   from transformers import AutoTokenizer, AutoModelForCausalLM
   tok = AutoTokenizer.from_pretrained("Narrativa/mT5-base-finetuned-tydiQA-xqa")
   model = AutoModelForCausalLM.from_pretrained(
@@ -68,8 +68,6 @@ O arquivo `.env` possibilita ajustar diversos parâmetros do projeto:
   prompt = f"question: {question_text} context: {context_text}"
   answer = tok.decode(model.generate(**tok(prompt, return_tensors='pt'))[0])
   ```
-- **Outros**: `CSV_FULL` e `CSV_INCR` podem apontar para arquivos CSV locais de
-  vulnerabilidades (opcional).
 
 #### TyDiQA
 

--- a/config.py
+++ b/config.py
@@ -12,9 +12,6 @@ load_dotenv(Path(__file__).resolve().with_name('.env'), override=True)
 # Valor padrao seguro para o comprimento maximo de sequencias
 DEFAULT_MAX_SEQ_LENGTH = 128
 
-# — NVD API Key (para incremental)
-NVD_API_KEY = os.getenv("NVD_API_KEY")
-
 # — PostgreSQL Connection
 PG_HOST     = os.getenv("PG_HOST")
 PG_PORT     = int(os.getenv("PG_PORT", "5432"))
@@ -22,10 +19,6 @@ PG_USER     = os.getenv("PG_USER")
 PG_PASSWORD = os.getenv("PG_PASSWORD")
 PG_DB_PDF   = os.getenv("PG_DB_PDF")
 PG_DB_QA    = os.getenv("PG_DB_QA")
-
-# — CSV locais (NVD)
-CSV_FULL = os.getenv("CSV_FULL")
-CSV_INCR = os.getenv("CSV_INCR")
 
 # — Modelos de Embedding & Chunking
 OLLAMA_EMBEDDING_MODEL  = os.getenv("OLLAMA_EMBEDDING_MODEL")

--- a/exemplo.env
+++ b/exemplo.env
@@ -1,9 +1,6 @@
 # =====================================================================
 # .env example
 # =====================================================================
-# — NVD API Key (para incremental)
-NVD_API_KEY=98dbb4f5-7540-4ca1-ae81-ffabf4b076b6
-
 # — PostgreSQL Connection
 PG_HOST=172.16.187.133
 PG_PORT=5432
@@ -63,6 +60,3 @@ SLIDING_WINDOW_OVERLAP_RATIO=0.25
 MAX_SEQ_LENGTH=128
 SEPARATORS="\n\n|\n|.|!|?|;"
 
-# — CSV locais (NVD)
-CSV_FULL=vulnerabilidades_full.csv
-CSV_INCR=vulnerabilidades_incrementais.csv


### PR DESCRIPTION
## Summary
- drop NVD_API_KEY, CSV_FULL and CSV_INCR from config
- delete those variables in README and example `.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f07f2e9a0832aa7ea783f17aba6ae