### PR TITLE
Add CVE training menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ PG_USER=vector_store
 PG_PASSWORD=senha
 PG_DB_PDF=vector_store_pdf
 PG_DB_QA=vector_store_pdf_qs
+PG_DB_CVE=cve
 
 TRAINING_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 EVAL_STEPS=500

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ PG_USER     = os.getenv("PG_USER")
 PG_PASSWORD = os.getenv("PG_PASSWORD")
 PG_DB_PDF   = os.getenv("PG_DB_PDF")
 PG_DB_QA    = os.getenv("PG_DB_QA")
+PG_DB_CVE   = os.getenv("PG_DB_CVE")
 
 # — Modelos de Embedding & Chunking
 OLLAMA_EMBEDDING_MODEL  = os.getenv("OLLAMA_EMBEDDING_MODEL")
@@ -88,7 +89,7 @@ DATALOADER_NUM_WORKERS      = int(os.getenv("DATALOADER_NUM_WORKERS", "0"))
 
 def validate_config():
     missing = []
-    for var in ("PG_HOST", "PG_PORT", "PG_USER", "PG_PASSWORD", "PG_DB_PDF", "PG_DB_QA"):
+    for var in ("PG_HOST", "PG_PORT", "PG_USER", "PG_PASSWORD", "PG_DB_PDF", "PG_DB_QA", "PG_DB_CVE"):
         if not globals().get(var):
             missing.append(var)
     if missing:

--- a/exemplo.env
+++ b/exemplo.env
@@ -8,6 +8,7 @@ PG_USER=vector_store
 PG_PASSWORD=senha
 PG_DB_PDF=vector_store_pdf
 PG_DB_QA=vector_store_pdf_qs
+PG_DB_CVE=cve
 
 # — Modelos de Embedding & Chunking
 OLLAMA_EMBEDDING_MODEL=mixedbread-ai/mxbai-embed-large-v1

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -92,3 +92,12 @@ def test_env_restored_on_exception_train_qa_model(monkeypatch, training_module):
     training_module.train_qa_model(1, 'cpu')
 
     assert os.environ.get('TRANSFORMERS_NO_CUDA') == 'orig'
+
+
+def test_env_restored_on_exception_train_cve_model(monkeypatch, training_module):
+    monkeypatch.setenv('TRANSFORMERS_NO_CUDA', 'orig')
+    monkeypatch.setattr(training_module, '_fetch_cve_texts', lambda *a, **k: (_ for _ in ()).throw(RuntimeError('fail')))
+
+    training_module.train_cve_model('cpu')
+
+    assert os.environ.get('TRANSFORMERS_NO_CUDA') == 'orig'


### PR DESCRIPTION
## Summary
- add CVE database config
- include CVE option in CLI database selection
- implement CVE training menu and training function
- document new PG_DB_CVE variable
- test CVE training flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507f629880832a91fa186a2ef39ae4