### PR TITLE
Disable HNSW index for 4096 dims

### DIFF
--- a/BD_PostgreSQL/Estrutura_Unificada.sql
+++ b/BD_PostgreSQL/Estrutura_Unificada.sql
@@ -104,7 +104,8 @@ DROP TRIGGER IF EXISTS tsv_full_trigger ON public.documents_4096;
 CREATE TRIGGER tsv_full_trigger
   BEFORE INSERT OR UPDATE ON public.documents_4096
   FOR EACH ROW EXECUTE FUNCTION public.update_tsv_full();
-CREATE INDEX IF NOT EXISTS idx_docs4096_emb_hnsw ON public.documents_4096 USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 200);
+-- HNSW indexes suportam até 2000 dimensões; para 4096 use apenas IVFFlat
+-- CREATE INDEX IF NOT EXISTS idx_docs4096_emb_hnsw ON public.documents_4096 USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 200);
 CREATE INDEX IF NOT EXISTS idx_docs4096_emb_ivf ON public.documents_4096 USING ivfflat (embedding vector_cosine_ops) WITH (lists = 400);
 CREATE INDEX IF NOT EXISTS idx_docs4096_tsv ON public.documents_4096 USING gin(tsv_full);
 CREATE INDEX IF NOT EXISTS idx_docs4096_meta ON public.documents_4096 USING gin(metadata);

--- a/BD_PostgreSQL/README.md
+++ b/BD_PostgreSQL/README.md
@@ -107,6 +107,7 @@ CREATE TRIGGER tsv_full_trigger
 - **Vetoriais (pgvector):** HNSW e IVFFlat
 - **GIN** em `tsv_full` e `metadata`
 - **GIN trigram** em campos textuais (`title`, `author`, `type`, `__parent`)
+- **Limite:** índices HNSW suportam apenas 2000 dimensões; para 4096 utilize somente IVFFlat
 
 ```sql
 -- Exemplo HNSW + IVFFlat


### PR DESCRIPTION
## Summary
- comment out the HNSW index for 4096 dimension embeddings
- note HNSW limit in the docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c9e5f048832aa8dbade06d7671f9